### PR TITLE
fixed the issue with normalization

### DIFF
--- a/js/USFMparser.js
+++ b/js/USFMparser.js
@@ -2,11 +2,11 @@ const match = require('./grammarOperations.js').match
 
 var warnings = []
 
-const multiLinePattern = new RegExp('(\\n\\r | \\n | \\r)[\\n\\r]+', 'g')
-const multiSpacePattern = new RegExp('  +', 'g')
-const trailingSpacePattern = new RegExp(' [\n\r]+', 'g')
 function normalize (str) {
   let newStr = ''
+  const multiLinePattern = new RegExp('(\\n\\r | \\n | \\r)[\\n\\r]+', 'g')
+  const multiSpacePattern = new RegExp('  +', 'g')
+  const trailingSpacePattern = new RegExp(' [\n\r]+', 'g')
   const bookCodePattern = new RegExp('\\id ([a-z][a-z][a-z])[ \\n\\r]', 'g')
   if (multiLinePattern.exec(str)) {
     warnings.push('Empty lines present. ')

--- a/js/USFMparser.js
+++ b/js/USFMparser.js
@@ -4,10 +4,10 @@ var warnings = []
 
 const multiLinePattern = new RegExp('(\\n\\r | \\n | \\r)[\\n\\r]+', 'g')
 const multiSpacePattern = new RegExp('  +', 'g')
-const bookCodePattern = new RegExp('\\id ([a-z][a-z][a-z])[ \\n\\r]', 'g')
 const trailingSpacePattern = new RegExp(' [\n\r]+', 'g')
 function normalize (str) {
   let newStr = ''
+  const bookCodePattern = new RegExp('\\id ([a-z][a-z][a-z])[ \\n\\r]', 'g')
   if (multiLinePattern.exec(str)) {
     warnings.push('Empty lines present. ')
   }


### PR DESCRIPTION
Alternate runs where throwing error for lowercase book code, while in every other run, it was successfully parsing it by normalizing the bookcode to uppercase and giving a warning.

Now the normalization is working properly in all executions, on demo site as well as while using in a test script.