### PR TITLE
feat: added support of top level li and footnote xt

### DIFF
--- a/grammar/usfm.ohm
+++ b/grammar/usfm.ohm
@@ -226,7 +226,7 @@ usfmBible{
 			efElement = newLine? backSlash  "ef"  spaceChar? footnoteContent* backSlash "ef*"spaceChar?
 			crossrefElement = newLine? backSlash  ("xt"|"x" | "ex") spaceChar?  crossrefContent* backSlash ("xt*"|"x*" | "ex*") spaceChar?
 
-			footnoteContent = text | footnoteContentElement | nestedCharElement 
+			footnoteContent = text | footnoteContentElement | nestedCharElement
 			footnoteContentElement = newLine? backSlash "fr" spaceChar
 							| newLine? backSlash "fr*" spaceChar?
 							| newLine? backSlash "fq" spaceChar
@@ -414,10 +414,10 @@ usfmBible{
 
 			li = (liElement)+
 			liElement = newLine? backSlash "li" number? spaceChar (text | charElement)*
+
+
 			
-			
-			
-						litElement = newLine? backSlash "lit" spaceChar ((chapterContentTextContent | notesElement | milestoneElement) | notesElement | milestoneElement)+
+			litElement = newLine? backSlash "lit" spaceChar ((chapterContentTextContent | notesElement | milestoneElement) | notesElement | milestoneElement)+
 
 
 			/* The text content vaild in different sections is determined by all the valid 

--- a/grammar/usfm.ohm
+++ b/grammar/usfm.ohm
@@ -129,7 +129,7 @@ usfmBible{
 
 			paraElement = newLine backSlash paraMarker spaceChar*
 			paraMarker = paraUnNumberedMarker | paraNumberedMarker
-			paraUnNumberedMarker =   ("po" | "m"  | "pr" | "cls" | "pmo" | "pm" | "pmc" | "pmr" | "pmi" | "nb" | "pc" | "b" | "pb" | "qr" | "qc" | "qd" | "lh" | "lf"  | "p" )
+			paraUnNumberedMarker =   ("po" | "m"  | "pr" | "cls" | "pmo" | "pm" | "pmc" | "pmr" | "pmi" | "nb" | "pc" | "b" | "pb" | "qr" | "qc" | "qd" | "lh" | "lf"  | "p" | "li" )
 			paraNumberedMarker =  ("pi" | "ph" | "q" | "qm" | "lim") number?
 
 			/* A verse is considered as a collection of objects which could be verse 
@@ -226,7 +226,7 @@ usfmBible{
 			efElement = newLine? backSlash  "ef"  spaceChar? footnoteContent* backSlash "ef*"spaceChar?
 			crossrefElement = newLine? backSlash  ("xt"|"x" | "ex") spaceChar?  crossrefContent* backSlash ("xt*"|"x*" | "ex*") spaceChar?
 
-			footnoteContent = text | footnoteContentElement | nestedCharElement
+			footnoteContent = text | footnoteContentElement | nestedCharElement 
 			footnoteContentElement = newLine? backSlash "fr" spaceChar
 							| newLine? backSlash "fr*" spaceChar?
 							| newLine? backSlash "fq" spaceChar
@@ -249,6 +249,8 @@ usfmBible{
 							| newLine? backSlash "fdc*" spaceChar?
 							| newLine? backSlash "fm" spaceChar
 							| newLine? backSlash "fm*" spaceChar?
+							| newLine? backSlash "+xt" spaceChar
+							| newLine? backSlash "+xt*" spaceChar?
 							
 
 			crossrefContent  = text | crossrefContentElement | nestedCharElement | attributesInCrossref
@@ -412,10 +414,10 @@ usfmBible{
 
 			li = (liElement)+
 			liElement = newLine? backSlash "li" number? spaceChar (text | charElement)*
-
-
 			
-			litElement = newLine? backSlash "lit" spaceChar ((chapterContentTextContent | notesElement | milestoneElement) | notesElement | milestoneElement)+
+			
+			
+						litElement = newLine? backSlash "lit" spaceChar ((chapterContentTextContent | notesElement | milestoneElement) | notesElement | milestoneElement)+
 
 
 			/* The text content vaild in different sections is determined by all the valid 


### PR DESCRIPTION
- added `+xt` and `+xt` to the `footnoteContentElement` grammar
- added support of `li` tag in `paraUnNumberedMarker`