### PR TITLE
JSON schema definition

### DIFF
--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -12,6 +12,7 @@ class JSONParser extends Parser {
     } else {
       this.JSONObject = JSONString;
     }
+    this.JSONObject = this.normalize();
     this.warnings = [];
     this.noNewLineMarkers = ['va', 'vp', 'qs', 'qac', 'litl', 'lik', 'lik1', 'lik2', 'lik3',
       'liv', 'liv1', 'liv2', 'liv3', 'th', 'th1', 'th2', 'th3', 'th4', 'th5',
@@ -38,8 +39,9 @@ class JSONParser extends Parser {
 
   normalize() {
     this.warnings = [];
-    // doesnot do any alterations. Method added because it is present in super class
-    const normJson = this.JSONObject;
+    const noBreakSpace = new RegExp('\u00A0', 'g');
+    let normJson = this.JSONObject;
+    normJson = normJson.replace(noBreakSpace, '~');
     return normJson;
   }
 

--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -5,9 +5,13 @@ const { JSONSchemaDefinition } = require('../schemas/file.js');
 const validateJSON = validate;
 
 class JSONParser extends Parser {
-  constructor(JSONObject) {
+  constructor(JSONString) {
     super();
-    this.JSONObject = JSONObject;
+    if (typeof JSONString === 'object') {
+      this.JSONObject = JSON.stringify(JSONString);
+    } else {
+      this.JSONObject = JSONString;
+    }
     this.warnings = [];
     this.noNewLineMarkers = ['va', 'vp', 'qs', 'qac', 'litl', 'lik', 'lik1', 'lik2', 'lik3',
       'liv', 'liv1', 'liv2', 'liv3', 'th', 'th1', 'th2', 'th3', 'th4', 'th5',
@@ -23,7 +27,13 @@ class JSONParser extends Parser {
   }
 
   validate() {
-    return validateJSON(this.JSONObject, JSONSchemaDefinition).valid;
+    let validJson = {};
+    try {
+      validJson = JSON.parse(this.JSONObject);
+    } catch (err) {
+      return false;
+    }
+    return validateJSON(validJson, JSONSchemaDefinition).valid;
   }
 
   normalize() {
@@ -35,9 +45,17 @@ class JSONParser extends Parser {
 
   toUSFM() {
     let usfmText = '';
-    const jsonObj = this.JSONObject;
+    let jsonObj = {};
+    try {
+      jsonObj = JSON.parse(this.JSONObject);
+    } catch (err) {
+      // console.log("<<<<JSON parsing error>>>")
+      const returnObj = { _messages: { _error: err.message } };
+      return returnObj;
+    }
     const validateObj = validateJSON(jsonObj, JSONSchemaDefinition);
     if (validateObj.valid === false) {
+      // console.log("<<<<JSON not valid for USFM grammar>>>")
       const errors = [];
       for (let i = 0; i < validateObj.errors.length; i += 1) {
         errors.push(validateObj.errors[i].stack);
@@ -177,7 +195,22 @@ class JSONParser extends Parser {
   }
 
   toCSV() {
-    const jsonOutput = this.JSONObject;
+    let jsonOutput = {};
+    try {
+      jsonOutput = JSON.parse(this.JSONObject);
+    } catch (err) {
+      const returnObj = { _messages: { _error: err.message } };
+      return returnObj;
+    }
+    const validateObj = validateJSON(jsonOutput, JSONSchemaDefinition);
+    if (validateObj.valid === false) {
+      const errors = [];
+      for (let i = 0; i < validateObj.errors.length; i += 1) {
+        errors.push(validateObj.errors[i].stack);
+      }
+      const returnObj = { _messages: { _error: errors } };
+      return returnObj;
+    }
     const bookName = jsonOutput.book.bookCode;
     const { chapters } = jsonOutput;
     let csvWriter = 'Book, Chapter, Verse, Text\n';
@@ -195,7 +228,22 @@ class JSONParser extends Parser {
   }
 
   toTSV() {
-    const jsonOutput = this.JSONObject;
+    let jsonOutput = {};
+    try {
+      jsonOutput = JSON.parse(this.JSONObject);
+    } catch (err) {
+      const returnObj = { _messages: { _error: err.message } };
+      return returnObj;
+    }
+    const validateObj = validateJSON(jsonOutput, JSONSchemaDefinition);
+    if (validateObj.valid === false) {
+      const errors = [];
+      for (let i = 0; i < validateObj.errors.length; i += 1) {
+        errors.push(validateObj.errors[i].stack);
+      }
+      const returnObj = { _messages: { _error: errors } };
+      return returnObj;
+    }
     const bookName = jsonOutput.book.bookCode;
     const { chapters } = jsonOutput;
     let csvWriter = 'Book\tChapter\tVerse\tText\n';

--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -1,4 +1,9 @@
 const { Parser } = require('./parser.js');
+const { validate } = require('jsonschema');
+const { JSONSchemaDefinition } = require('../schemas/file.js')
+
+
+const validateJSON = validate;
 
 class JSONParser extends Parser {
   constructor(JSONObject) {
@@ -19,13 +24,7 @@ class JSONParser extends Parser {
   }
 
   validate() {
-    try {
-      // try parsing and converting to USFM to make sure the format is correct
-      this.toUSFM(this.JSONObject);
-      return true;
-    } catch (err) {
-      return false;
-    }
+    return validateJSON(this.JSONObject, JSONSchemaDefinition).valid
   }
 
   normalize() {
@@ -38,6 +37,15 @@ class JSONParser extends Parser {
   toUSFM() {
     let usfmText = '';
     const jsonObj = this.JSONObject;
+    const validateObj = validateJSON(jsonObj, JSONSchemaDefinition);
+    if(validateObj.valid === false) {
+      let errors = [];
+      for (let i=0; i<validateObj.errors.length; i=i+1) {
+        errors.push(validateObj.errors[i].stack)
+      }
+      let returnObj = { "_messages" : { "_error": errors } };
+      return returnObj;
+    }
     usfmText += '\\id ';
     usfmText += jsonObj.book.bookCode;
     if (Object.prototype.hasOwnProperty.call(jsonObj.book, 'description')) {

--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -1,7 +1,6 @@
-const { Parser } = require('./parser.js');
 const { validate } = require('jsonschema');
-const { JSONSchemaDefinition } = require('../schemas/file.js')
-
+const { Parser } = require('./parser.js');
+const { JSONSchemaDefinition } = require('../schemas/file.js');
 
 const validateJSON = validate;
 
@@ -24,7 +23,7 @@ class JSONParser extends Parser {
   }
 
   validate() {
-    return validateJSON(this.JSONObject, JSONSchemaDefinition).valid
+    return validateJSON(this.JSONObject, JSONSchemaDefinition).valid;
   }
 
   normalize() {
@@ -38,12 +37,12 @@ class JSONParser extends Parser {
     let usfmText = '';
     const jsonObj = this.JSONObject;
     const validateObj = validateJSON(jsonObj, JSONSchemaDefinition);
-    if(validateObj.valid === false) {
-      let errors = [];
-      for (let i=0; i<validateObj.errors.length; i=i+1) {
-        errors.push(validateObj.errors[i].stack)
+    if (validateObj.valid === false) {
+      const errors = [];
+      for (let i = 0; i < validateObj.errors.length; i += 1) {
+        errors.push(validateObj.errors[i].stack);
       }
-      let returnObj = { "_messages" : { "_error": errors } };
+      const returnObj = { _messages: { _error: errors } };
       return returnObj;
     }
     usfmText += '\\id ';

--- a/js/USFMparser.js
+++ b/js/USFMparser.js
@@ -18,6 +18,7 @@ class USFMParser extends Parser {
     const multiSpacePattern = new RegExp('  +', 'g');
     const trailingSpacePattern = new RegExp(' +[\\n\\r]', 'g');
     const bookCodePattern = new RegExp('\\\\id ([a-z][a-z][a-z])[ \\n\\r]', 'g');
+    const nonBreakingSpacePattern = new RegExp('~', 'g');
     if (multiLinePattern.exec(str)) {
       this.warnings.push('Empty lines present. ');
     }
@@ -36,6 +37,7 @@ class USFMParser extends Parser {
       newStr = newStr.replace(bookCode, bookCode.toUpperCase());
       this.warnings.push('Book code is in lowercase. ');
     }
+    newStr = newStr.replace(nonBreakingSpacePattern, '\u00A0');
     this.usfmString = newStr;
     return newStr;
   }

--- a/js/USFMparser.js
+++ b/js/USFMparser.js
@@ -69,6 +69,39 @@ class USFMParser extends Parser {
         this.warnings = this.warnings.concat(matchObj.warnings);
         // console.log(this.warnings)
       }
+
+      // POST processing to check and warn for consecutive paragraph markers
+      let lastObject = '';
+      for (let i = 0; i < jsonOutput.chapters.length; i += 1) {
+        for (let j = 0; j < jsonOutput.chapters[i].contents.length; j += 1) {
+          if (typeof jsonOutput.chapters[i].contents[j] === 'object') {
+            if (Object.keys(jsonOutput.chapters[i].contents[j])[0] === 'verseNumber') {
+              for (let k = 0; k < jsonOutput.chapters[i].contents[j].contents.length; k += 1) {
+                if (Object.keys(jsonOutput.chapters[i].contents[j].contents[k]).length === 1
+                    && Object.values(jsonOutput.chapters[i].contents[j].contents[k])[0] === null) {
+                  if (lastObject === 'para marker') {
+                    this.warnings.push('Consecutive use of empty paragraph markers. ');
+                  } else {
+                    lastObject = 'para marker';
+                  }
+                } else {
+                  lastObject = 'not para marker';
+                }
+              }
+            } else if (Object.keys(jsonOutput.chapters[i].contents[j]).length === 1
+                && Object.values(jsonOutput.chapters[i].contents[j])[0] === null) {
+              if (lastObject === 'para marker') {
+                this.warnings.push('Consecutive use of empty paragraph markers. ');
+              } else {
+                lastObject = 'para marker';
+              }
+            } else {
+              lastObject = 'not para marker';
+            }
+          }
+        }
+      }
+
       if (filter === 'clean') {
         const newJsonOutput = { book: {}, chapters: [] };
         newJsonOutput.book.bookCode = jsonOutput.book.bookCode;

--- a/js/grammarOperations-relaxed.js
+++ b/js/grammarOperations-relaxed.js
@@ -11,12 +11,15 @@ const sem = bib.createSemantics();
 // We need to know which all marker's contents should be considered as verseText
 // while composing the .verseText property of each verse element.
 // This list is consulted for that
-const verseCarryingMarkers = ['li', 'li1', 'li2', 'li3', 'litl',
+const verseCarryingMarkers = ['li', 'li1', 'li2', 'li3', 'lh', 'lf', 'lim', 'litl',
   'lik', 'liv', 'liv1', 'liv2', 'liv3', 'th', 'th1', 'th2', 'th3',
   'thr', 'thr1', 'thr2', 'thr3', 'tc', 'tc1', 'tc2', 'tc3', 'tcr',
   'tcr1', 'tcr2', 'tcr3', 'add', 'bk', 'dc', 'k', 'lit', 'nd', 'ord',
   'pn', 'png', 'addpn', 'qt', 'sig', 'sls', 'tl', 'wj', 'em', 'bd',
-  'it', 'bdit', 'no', 'sc', 'sup', 'w', 'rb', 'wa', 'wg', 'wh', 'pro'];
+  'it', 'bdit', 'no', 'sc', 'sup', 'w', 'rb', 'wa', 'wg', 'wh', 'pro',
+  '+add', '+bk', '+dc', '+k', '+lit', '+nd', '+ord', '+pn', '+png',
+  '+addpn', '+qt', '+sig', '+sls', '+tl', '+wj', '+em', '+bd', '+it',
+  '+bdit', '+no', '+sc', '+sup', '+w', '+rb', '+wa', '+wg', '+wh', '+pro'];
 
 // In normal grammar these markers are implemented as not containing text or other contents.
 // The relaxed grammar doesnot implement makers separately but have general rules for all.
@@ -84,7 +87,7 @@ sem.addOperation('buildJson', {
   idMarker(_1, _2, _3, _4, cod, desc) {
     const res = {
       id: {
-        bookCode: cod.sourceString,
+        bookCode: cod.sourceString.trim(),
       },
     };
     if (desc.sourceString !== '') {

--- a/js/grammarOperations.js
+++ b/js/grammarOperations.js
@@ -1074,6 +1074,7 @@ sem.addOperation('composeJson', {
   },
 
   liElementWithoutText(_1, _2, marker, _4) {
+    emitter.emit('warning', new Error('\\li used without content'));
     return { li: null };
   },
 
@@ -1088,6 +1089,7 @@ sem.addOperation('composeJson', {
   },
 
   lhElementWithoutText(_1, _2, marker, _4) {
+    emitter.emit('warning', new Error('\\lh used without content'));
     return { lh: null };
   },
 
@@ -1102,6 +1104,7 @@ sem.addOperation('composeJson', {
   },
 
   lfElementWithoutText(_1, _2, marker, _4) {
+    emitter.emit('warning', new Error('\\lf used without content'));
     return { lf: null };
   },
 
@@ -1117,6 +1120,7 @@ sem.addOperation('composeJson', {
   },
 
   limElementWithoutText(_1, _2, marker, number, _4) {
+    emitter.emit('warning', new Error('\\lim used without content'));
     return { lim: null };
   },
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 const { USFMParser } = require('./USFMparser.js');
 const { JSONParser } = require('./JSONparser.js');
-const { JSONSchemaDefinition } = require('../schemas/file.js')
+const { JSONSchemaDefinition } = require('../schemas/file.js');
 
 const FILTER = { SCRIPTURE: 'clean', ALL: 'normal' };
 const LEVEL = { RELAXED: 'relaxed', STRICT: 'normal' };
@@ -10,4 +10,4 @@ exports.LEVEL = LEVEL;
 
 exports.USFMParser = USFMParser;
 exports.JSONParser = JSONParser;
-exports.JSONSchemaDefinition = JSONSchemaDefinition
+exports.JSONSchemaDefinition = JSONSchemaDefinition;

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 const { USFMParser } = require('./USFMparser.js');
 const { JSONParser } = require('./JSONparser.js');
+const { JSONSchemaDefinition } = require('../schemas/file.js')
 
 const FILTER = { SCRIPTURE: 'clean', ALL: 'normal' };
 const LEVEL = { RELAXED: 'relaxed', STRICT: 'normal' };
@@ -9,3 +10,4 @@ exports.LEVEL = LEVEL;
 
 exports.USFMParser = USFMParser;
 exports.JSONParser = JSONParser;
+exports.JSONSchemaDefinition = JSONSchemaDefinition

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "usfm-grammar",
-    "version": "2.0.0-beta.4",
+    "version": "2.0.0-beta.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1112,6 +1112,11 @@
             "requires": {
                 "minimist": "^1.2.0"
             }
+        },
+        "jsonschema": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+            "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
         },
         "levn": {
             "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "test-on-github": "mocha --expose-gc --timeout 40000 --ignore test/test_filesFromWild.js"
     },
     "dependencies": {
+        "jsonschema": "^1.4.0",
         "ohm-js": "^15.2.1",
         "yargs": "^16.0.3"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "usfm-grammar",
     "description": "An elegant [USFM](https://github.com/ubsicap/usfm) parser (or validator) that uses a [parsing expression grammar](https://en.wikipedia.org/wiki/Parsing_expression_grammar) to model USFM. The grammar is written using [ohm](https://ohmlang.github.io/). Only USFM 3.0 is supported. The parsed USFM is an intuitive and easy to manipulate JSON structure that allows for painless extraction of scripture and other content from the markup. USFM Grammar is also capable of reconverting the generated JSON back to USFM.",
-    "version": "2.0.0-beta.6",
+    "version": "2.0.0-beta.7",
     "main": "./js/main.js",
     "scripts": {
         "test": "mocha --expose-gc --timeout 40000",

--- a/schemas/file.js
+++ b/schemas/file.js
@@ -1,6 +1,28 @@
 exports.JSONSchemaDefinition = {
   $id: 'https://usfm.vachanengine.org/schemas/file.json',
   definitions: {
+    chapterContent: {
+      $id: '#chapterContent',
+      if: {
+        type: 'object',
+        required: ['verseNumber'],
+      },
+      then: {
+        $ref: '#verse',
+      },
+      else: {
+        if: {
+          type: 'object',
+          required: ['verseText'],
+        },
+        then: {
+          $ref: '#verse',
+        },
+        else: {
+          $ref: '#otherElement',
+        },
+      },
+    },
     verse: {
       $id: '#verse',
       type: 'object',
@@ -9,9 +31,29 @@ exports.JSONSchemaDefinition = {
         verseText: { type: 'string' },
         contents: {
           type: 'array',
+          items: {
+            $ref: '#otherElement',
+          },
         },
       },
       required: ['verseNumber', 'verseText'],
+    },
+    otherElement: {
+      $id: '#otherElement',
+      oneOf: [
+        { type: 'string' },
+        { type: 'null' },
+        {
+          type: 'array',
+          items: { $ref: '#otherElement' },
+        },
+        {
+          type: 'object',
+          patternProperties: {
+            '(^[^ ]+$)': '#otherElement',
+          },
+        },
+      ],
     },
   },
 
@@ -29,22 +71,25 @@ exports.JSONSchemaDefinition = {
         },
         meta: {
           type: 'array',
+          items: {
+            $ref: '#otherElement',
+          },
         },
       },
       required: ['bookCode'],
     },
     chapters: {
       type: 'array',
-      contains: {
+      items: {
         properties: {
           chapterNumber: { type: 'string' },
           contents: {
             type: 'array',
-            contains: { $ref: '#verse' },
-
+            items: { $ref: '#chapterContent' },
           },
         },
         required: ['chapterNumber', 'contents'],
+        additionalProperties: false,
       },
     },
     _messages: {

--- a/schemas/file.js
+++ b/schemas/file.js
@@ -1,60 +1,60 @@
 exports.JSONSchemaDefinition = {
-	"$id": "https://usfm.vachanengine.org/schemas/file.json",
-	"definitions": {
-		"verse": {
-			"$id": "#verse",
-			"type": "object",
-			"properties": {
-				"verseNumber" : { "type": "string" },
-				"verseText" : { "type": "string"},
-				"contents" : {
-					"type" : "array"
-				}
-			},
-			"required": ["verseNumber", "verseText"]
-		}
-	},
+  $id: 'https://usfm.vachanengine.org/schemas/file.json',
+  definitions: {
+    verse: {
+      $id: '#verse',
+      type: 'object',
+      properties: {
+        verseNumber: { type: 'string' },
+        verseText: { type: 'string' },
+        contents: {
+          type: 'array',
+        },
+      },
+      required: ['verseNumber', 'verseText'],
+    },
+  },
 
-	"type": "object",
-	"properties": {
-		"book": {
-			"type": "object",
-			"properties": {
-				"bookCode": {
-					"type": "string",
-					"enum": ["GEN", "EXO", "LEV", "NUM", "DEU", "JOS", "JDG", "RUT", "1SA", "2SA", "1KI", "2KI", "1CH", "2CH", "EZR", "NEH", "EST", "JOB", "PSA", "PRO", "ECC", "SNG", "ISA", "JER", "LAM", "EZK", "DAN", "HOS", "JOL", "AMO", "OBA", "JON", "MIC", "NAM", "HAB", "ZEP", "HAG", "ZEC", "MAL", "MAT", "MRK", "LUK", "JHN", "ACT", "ROM", "1CO", "2CO", "GAL", "EPH", "PHP", "COL", "1TH", "2TH", "1TI", "2TI", "TIT", "PHM", "HEB", "JAS", "1PE", "2PE", "1JN", "2JN", "3JN", "JUD", "REV", "TOB", "JDT", "ESG", "WIS", "SIR", "BAR", "LJE", "S3Y", "SUS", "BEL", "1MA", "2MA", "3MA", "4MA", "1ES", "2ES", "MAN", "PS2", "ODA", "PSS", "EZA", "5EZ", "6EZ", "DAG", "PS3", "2BA", "LBA", "JUB", "ENO", "1MQ", "2MQ", "3MQ", "REP", "4BA", "LAO", "FRT", "BAK", "OTH", "INT", "CNC", "GLO", "TDX", "NDX"]
-				},
-				"description": {
-					"type": "string"
-				},
-				"meta": {
-					"type": "array"
-				}
-			},
-			"required": ["bookCode"]
-		},
-		"chapters": {
-			"type": "array",
-			"contains" : { 
-				"properties": {
-					"chapterNumber": { "type": "string" },
-					"contents": {
-						"type": "array",
-						"contains": { "$ref": "#verse" },
+  type: 'object',
+  properties: {
+    book: {
+      type: 'object',
+      properties: {
+        bookCode: {
+          type: 'string',
+          enum: ['GEN', 'EXO', 'LEV', 'NUM', 'DEU', 'JOS', 'JDG', 'RUT', '1SA', '2SA', '1KI', '2KI', '1CH', '2CH', 'EZR', 'NEH', 'EST', 'JOB', 'PSA', 'PRO', 'ECC', 'SNG', 'ISA', 'JER', 'LAM', 'EZK', 'DAN', 'HOS', 'JOL', 'AMO', 'OBA', 'JON', 'MIC', 'NAM', 'HAB', 'ZEP', 'HAG', 'ZEC', 'MAL', 'MAT', 'MRK', 'LUK', 'JHN', 'ACT', 'ROM', '1CO', '2CO', 'GAL', 'EPH', 'PHP', 'COL', '1TH', '2TH', '1TI', '2TI', 'TIT', 'PHM', 'HEB', 'JAS', '1PE', '2PE', '1JN', '2JN', '3JN', 'JUD', 'REV', 'TOB', 'JDT', 'ESG', 'WIS', 'SIR', 'BAR', 'LJE', 'S3Y', 'SUS', 'BEL', '1MA', '2MA', '3MA', '4MA', '1ES', '2ES', 'MAN', 'PS2', 'ODA', 'PSS', 'EZA', '5EZ', '6EZ', 'DAG', 'PS3', '2BA', 'LBA', 'JUB', 'ENO', '1MQ', '2MQ', '3MQ', 'REP', '4BA', 'LAO', 'FRT', 'BAK', 'OTH', 'INT', 'CNC', 'GLO', 'TDX', 'NDX'],
+        },
+        description: {
+          type: 'string',
+        },
+        meta: {
+          type: 'array',
+        },
+      },
+      required: ['bookCode'],
+    },
+    chapters: {
+      type: 'array',
+      contains: {
+        properties: {
+          chapterNumber: { type: 'string' },
+          contents: {
+            type: 'array',
+            contains: { $ref: '#verse' },
 
-					}
-				},
-				"required": ["chapterNumber", "contents"]
-			}
-		},
-		"_messages": {
-			"type": "object",
-			"properties": {
-				"_warnings": {
-					"type": "array"
-				}
-			}
-		}
-	},
-	"required": ["book", "chapters"]
+          },
+        },
+        required: ['chapterNumber', 'contents'],
+      },
+    },
+    _messages: {
+      type: 'object',
+      properties: {
+        _warnings: {
+          type: 'array',
+        },
+      },
+    },
+  },
+  required: ['book', 'chapters'],
 };

--- a/schemas/file.js
+++ b/schemas/file.js
@@ -1,4 +1,4 @@
-{
+exports.JSONSchemaDefinition = {
 	"$id": "https://usfm.vachanengine.org/schemas/file.json",
 	"definitions": {
 		"verse": {
@@ -40,7 +40,8 @@
 					"chapterNumber": { "type": "string" },
 					"contents": {
 						"type": "array",
-						"contains": { "$ref": "#verse" }
+						"contains": { "$ref": "#verse" },
+
 					}
 				},
 				"required": ["chapterNumber", "contents"]
@@ -56,4 +57,4 @@
 		}
 	},
 	"required": ["book", "chapters"]
-}
+};

--- a/schemas/file.json
+++ b/schemas/file.json
@@ -1,0 +1,59 @@
+{
+	"$id": "https://usfm.vachanengine.org/schemas/file.json",
+	"definitions": {
+		"verse": {
+			"$id": "#verse",
+			"type": "object",
+			"properties": {
+				"verseNumber" : { "type": "string" },
+				"verseText" : { "type": "string"},
+				"contents" : {
+					"type" : "array"
+				}
+			},
+			"required": ["verseNumber", "verseText"]
+		}
+	},
+
+	"type": "object",
+	"properties": {
+		"book": {
+			"type": "object",
+			"properties": {
+				"bookCode": {
+					"type": "string",
+					"enum": ["GEN", "EXO", "LEV", "NUM", "DEU", "JOS", "JDG", "RUT", "1SA", "2SA", "1KI", "2KI", "1CH", "2CH", "EZR", "NEH", "EST", "JOB", "PSA", "PRO", "ECC", "SNG", "ISA", "JER", "LAM", "EZK", "DAN", "HOS", "JOL", "AMO", "OBA", "JON", "MIC", "NAM", "HAB", "ZEP", "HAG", "ZEC", "MAL", "MAT", "MRK", "LUK", "JHN", "ACT", "ROM", "1CO", "2CO", "GAL", "EPH", "PHP", "COL", "1TH", "2TH", "1TI", "2TI", "TIT", "PHM", "HEB", "JAS", "1PE", "2PE", "1JN", "2JN", "3JN", "JUD", "REV", "TOB", "JDT", "ESG", "WIS", "SIR", "BAR", "LJE", "S3Y", "SUS", "BEL", "1MA", "2MA", "3MA", "4MA", "1ES", "2ES", "MAN", "PS2", "ODA", "PSS", "EZA", "5EZ", "6EZ", "DAG", "PS3", "2BA", "LBA", "JUB", "ENO", "1MQ", "2MQ", "3MQ", "REP", "4BA", "LAO", "FRT", "BAK", "OTH", "INT", "CNC", "GLO", "TDX", "NDX"]
+				},
+				"description": {
+					"type": "string"
+				},
+				"meta": {
+					"type": "array"
+				}
+			},
+			"required": ["bookCode"]
+		},
+		"chapters": {
+			"type": "array",
+			"contains" : { 
+				"properties": {
+					"chapterNumber": { "type": "string" },
+					"contents": {
+						"type": "array",
+						"contains": { "$ref": "#verse" }
+					}
+				},
+				"required": ["chapterNumber", "contents"]
+			}
+		},
+		"_messages": {
+			"type": "object",
+			"properties": {
+				"_warnings": {
+					"type": "array"
+				}
+			}
+		}
+	},
+	"required": ["book", "chapters"]
+}

--- a/test/test_apis.js
+++ b/test/test_apis.js
@@ -2,6 +2,23 @@ const assert = require('assert');
 const grammar = require('../js/main.js');
 
 const inputUSFM = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\toc1 The Acts of the Apostles\n\\toc2 Acts\n\\ip One of these brothers, Joseph, had become...\n\\ipr (50.24)\n\\c 1\n\\po\n\\v 1 This is the Good News ...\n\\pr “And all the people will answer, ‘Amen!’\n\\v 2 It began as ..\n\\q1 “God said, ‘I will send ...\n\\q2 to open the way for you.’\n\\q1\n\\v 3 Someone is shouting in the desert,\n\\q2 ‘Get the road ready for the Lord;\n\\q2 make a straight path for him to travel!’”\n\\b\n\\m\n\\v 4 So John appeared in the desert, ...\n\\pmo We apostles and leaders send friendly\n\\pm\n\\v 24 We have heard that some ...\n\\v 25 So we met together and decided ..\n\\c 8\n\\nb\n\\v 26 These men have risked their lives ..\n\\pc I AM THE GREAT CITY OF BABYLON, ...\n\\v 27 We are also sending Judas and Silas, ..\n\\pm\n\\v 37 Jesus answered:\n\\pi The one who scattered the good ..\n\\mi\n\\v 28 The Holy Spirit has shown...\n\\pmc We send our best wishes.\n\\cls May God\'s grace be with you.';
+const inputJSON = {
+  book: {
+    bookCode: 'GEN',
+    description: 'some text',
+  },
+  chapters: [{
+    chapterNumber: '3',
+    contents: [{ p: null },
+      {
+        verseNumber: '1',
+        verseText: 'This is a prayer of the prophet Habakkuk:',
+        contents: ['This is a prayer of the prophet Habakkuk:'],
+      },
+    ],
+  },
+  ],
+};
 
 describe('API tests', () => {
   beforeEach(() => {
@@ -143,5 +160,17 @@ describe('API tests', () => {
     assert(typeof tsvString === 'string');
     assert(tsvString.startsWith('Book\tChapter\tVerse'));
     assert.strictEqual(tsvString.split('\n').length, 12);
+  });
+
+  it('JSONParser.validate from JSON object', () => {
+    const jsonParser = new grammar.JSONParser(inputJSON);
+    const validity = jsonParser.validate();
+    assert(validity, true);
+  });
+
+  it('JSONParser.validate from JSON string', () => {
+    const jsonParser = new grammar.JSONParser(JSON.stringify(inputJSON));
+    const validity = jsonParser.validate();
+    assert(validity, true);
   });
 });

--- a/test/test_backward.js
+++ b/test/test_backward.js
@@ -3,6 +3,37 @@ const grammar = require('../js/main.js');
 
 // const parser = new grammar.USFMparser();
 // const reverseParser = new grammar.JSONparser();
+
+function usfmConvertedJsonValidatorTest(inputUsfm) {
+  let usfmParser = new grammar.USFMParser(inputUsfm);
+  let jsonOutput = usfmParser.toJSON();
+  let jsonParser = new grammar.JSONParser(jsonOutput);
+  let validity = jsonParser.validate();
+  // if (validity === false) {
+  //   console.log(jsonParser.toUSFM())
+  // }
+  assert(validity, true);
+
+  usfmParser = new grammar.USFMParser(inputUsfm, grammar.LEVEL.RELAXED);
+  jsonOutput = usfmParser.toJSON();
+  jsonParser = new grammar.JSONParser(jsonOutput);
+  validity = jsonParser.validate();
+  // if (validity === false) {
+  //   console.log(jsonParser.toUSFM())
+  // }
+  assert(validity, true);
+}
+
+function jsonValidatorNegativeTest(inputJson) {
+  const jsonParser = new grammar.JSONParser(inputJson);
+  const validity = jsonParser.validate();
+  const usfmOutput = jsonParser.toUSFM();
+  assert.strictEqual(validity, false);
+  assert.strictEqual('_messages' in usfmOutput, true);
+  assert.strictEqual('_error' in usfmOutput._messages, true);
+  // console.log(usfmOutput._messages._error);
+}
+
 beforeEach(() => {
   if (global.gc) { global.gc(); }
 });
@@ -232,5 +263,280 @@ describe('Reverse Parse: More Complex Components', () => {
     jsonParser = new grammar.JSONParser(jsonOutput);
     outputUsfm = jsonParser.toUSFM();
     assert.strictEqual(outputUsfm.replace(/[\s\n\r]/g, ''), inputUsfm.replace(/[\s\n\r]/g, ''));
+  });
+});
+
+describe('JSON validation: valid jsons created from USFMs', () => {
+  it('minimum required markers', () => {
+    const inputUsfm = '\\id PHM Longer Heading\n\\c 1\n\\p\n\\v 1 '
+      + 'ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('v with empty text', () => {
+    const inputUsfm = '\\id PHM Longer Heading\n\\c 1\n\\p\n\\v 1\n';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('The identification markers with right syntax', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\ide UTF-8\n\\ide CP-1252\n\\ide Custom (TGUARANI.TTF)\n\\sts 2\n\\h1 Matthew\n\\rem Assigned to <translator\'s name>.\n\\rem First draft complete, waiting for checks.\n\\toc1 The Gospel According to Matthew\n\\toc2 Matthew\n\\toc3 Mat\n\\toca1 മത്തായി എഴുതിയ സുവിശേഷം\n\\toca2 മത്തായി\n\\toca3 മത്താ\n\\c 1\n\\p\n\\v 1 ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...\n';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Realxed mode supports chapter without verse', () => {
+    const inputUsfm = '\\id PHM Longer Heading\n\\c 1\n\\p\n';
+
+    const usfmParser = new grammar.USFMParser(inputUsfm, grammar.LEVEL.RELAXED);
+    const jsonOutput = usfmParser.toJSON();
+    const jsonParser = new grammar.JSONParser(jsonOutput);
+    const validity = jsonParser.validate();
+    assert(validity, true);
+  });
+
+  it('Introduction markers-Part I plus \\bk and \\em, all with right syntax', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\h SAN MARCOS\n\\mt2 Evangelio según\n\\mt1 SAN MARCOS\n\\imt1 INTRODUCCIÓN\n\\is1 Importancia del evangelio de Marcos\n\\ip Este evangelio, segundo de los libros del NT, contiene poco material que no aparezca igualmente en \\bk Mateo\\bk* y \\bk Lucas.\\bk*\n\\ipi Many Protestants consider the following books to be Apocrypha as defined above: Tobit, Judith, additions to Esther (as found in Greek Esther in the CEV) ...\n\\imi \\em Translation it is that opens the window, to let in the light; that breaks the shell, that we may eat the kernel; that puts aside the curtain, that we may look into the most holy place; that removes the cover of the well, that we may come by the water.\\em* (“The Translators to the Reader,” King James Version, 1611).\n\\im The most important document in the history of the English language is the \\bk King James Version\\bk* of the Bible...\n\\c 1\n\\p\n\\v 1 ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Introduction markers-Part II, all with right syntax', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\ip One of these brothers, Joseph, had become the governor of Egypt. But Joseph knew that God would someday keep his promise to his people:\n\\ib\n\\ipq Before Joseph died, he told his brothers, “I won\'t live much longer. \n\\imq But God will take care of you and lead you out of Egypt to the land he promised Abraham, Isaac, and Jacob.”\n\\ipr (50.24)\n\\iq1 God our Savior showed us\n\\iq2 how good and kind he is.\n\\iq1 He saved us because\n\\iq2 of his mercy,\n\\iot Outline of Contents\n\\io1 The beginning of the gospel \\ior (1.1-13)\\ior*\n\\io1 Jesus\' public ministry in Galilee \\ior (1.14–9.50)\\ior*\n\\io1 From Galilee to Jerusalem \\ior (10.1-52)\\ior*\n\\io1 The last week in and near Jerusalem\n\\c 1\n\\p\n\\v 1 ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Introduction markers-Part III plus \\k and \\w, all with right syntax', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\ip However, he is more than a teacher, healer, or \\w miracle\\w*-worker. He is also ...\n\\ili 1 \\k The Messiah\\k* is the one promised by God, the one who would come and free God\'s people. By the time \\bk The Gospel of Mark\\bk* appeared, the title "Messiah" (in Greek, "\\w christ\\w*") had become ...\n\\ili 2 \\k The Son of God\\k* is the title by which the heavenly voice addresses Jesus at his baptism (1.11) and his transfiguration ...\n\\ili 3 \\k The Son of Man\\k* is the title most...\n\\imte End of the Introduction to the Gospel of Mark\n\\ie\n\\c 1\n\\p\n\\v 1 ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\iex Written to the Romans from Corinthus, and sent by Phebe servant of the church at Cenchrea.\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...\n';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Titles, Headings, and Labels with right syntax', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\toc1 The Acts of the Apostles\n\\toc2 Acts\n\\mt1 THE ACTS\n\\mt2 of the Apostles\n\\mte2 The End of the Gospel according to\n\\mte1 John \n\\c 1\n\\ms BOOK ONE\n\\mr (Psalms 1–41)\n\\s True Happiness\n\\p\n\\v 1 ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\s1 The Thirty Wise Sayings\n\\sr (22.17--24.22)\n\\r (Mark 1.1-8; Luke 3.1-18; John 1.19-28)\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\sd2\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...\n\\v 4 The Son was made greater than the angels, just as the name that God gave him is greater than theirs.\n\\v 5 For God never said to any of his angels,\n\\sp God\n\\q1 "You are my Son;\n\\q2 today I have become your Father."\n\\rq Psa 2.7\\rq*\n\\b\n\\m Nor did God say about any angel,\n\\q1 "I will be his Father,\n\\q2 and he will be my Son."\n\\rq 2Sa 7.14; 1Ch 17.13\\rq*\n\\c 3\n\\s1 Trust in God under Adversity\n\\d A Psalm of David, when he fled from his son Absalom.\n\\q1\n\\v 1 O \\nd Lord\\nd*, how many are my foes!\n\\q2 Many are rising against me;\n\\q1\n\\v 2 many are saying to me,\n\\q2 “There is no help for you in God.” \\qs Selah\\qs*';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Chapters and verses, plus \\r', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\c 1\n\\cl Matthew\n\\ca 2\\ca*\n\\cp M\n\\cd Additional deacription about the chapter\n\\s1 The Ancestors of Jesus Christ\n\\r (Luke 3.23-38)\n\\p\n\\v 1 \\va 3\\va* \\vp 1b\\vp* This is the list of the ancestors of Jesus Christ, a descendant of David, who was a descendant of Abraham.\n\\c 2\n\\p\n\\v 1 ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...\n\\v 2 നമ്മുടെ പിതാവായ ...\n\\iex Written to the Romans from Corinthus, and sent by Phebe servant of the church at Cenchrea.\n\\p\n\\v 3 കർത്താവായ യേശുവിനോടും ...';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Paragraph markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\toc1 The Acts of the Apostles\n\\toc2 Acts\n\\ip One of these brothers, Joseph, had become...\n\\ipr (50.24)\n\\c 1\n\\po\n\\v 1 This is the Good News ...\n\\pr “And all the people will answer, ‘Amen!’\n\\v 2 It began as ..\n\\q1 “God said, ‘I will send ...\n\\q2 to open the way for you.’\n\\q1\n\\v 3 Someone is shouting in the desert,\n\\q2 ‘Get the road ready for the Lord;\n\\q2 make a straight path for him to travel!’”\n\\b\n\\m\n\\v 4 So John appeared in the desert, ...\n\\pmo We apostles and leaders send friendly\n\\pm\n\\v 24 We have heard that some ...\n\\v 25 So we met together and decided ..\n\\c 8\n\\nb\n\\v 26 These men have risked their lives ..\n\\pc I AM THE GREAT CITY OF BABYLON, ...\n\\v 27 We are also sending Judas and Silas, ..\n\\pm\n\\v 37 Jesus answered:\n\\pi The one who scattered the good ..\n\\mi\n\\v 28 The Holy Spirit has shown...\n\\pmc We send our best wishes.\n\\cls May God\'s grace be with you.';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Poetry Markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\toc1 The Acts of the Apostles\n\\toc2 Acts\n\\ip One of these brothers, Joseph, had become...\n\\ipr (50.24)\n\\c 136\n\\qa Aleph\n\\s1 God\'s Love Never Fails\n\\q1\n\\v 1 \\qac P\\qac*Praise the \\nd Lord\\nd*! He is good.\n\\qr God\'s love never fails \\qs Selah\\qs*\n\\q1\n\\v 2 Praise the God of all gods.\n\\q1 May his glory fill the whole world.\n\\b\n\\qc Amen! Amen!\n\\qd For the director of music. On my stringed instruments.\n\\b\n\\v 18 God\'s spirit took control of one of them, Amasai, who later became the commander of “The Thirty,” and he called out,\n\\qm1 “David son of Jesse, we are yours!\n\\qm1 Success to you and those who help you!\n\\qm1 God is on your side.”\n\\b\n\\m David welcomed them and made them officers in his army.';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('List Markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\toc1 The Acts of the Apostles\n\\toc2 Acts\n\\ip One of these brothers, Joseph, had become...\n\\ipr (50.24)\n\\c 136\n\\p\n\\s1 God\'s Love Never Fails\n\\lh\n\\v 16-22 This is the list of the administrators of the tribes of Israel:\n\\li1 Reuben - Eliezer son of Zichri\n\\li1 Simeon - Shephatiah son of Maacah\n\\li1 Levi - Hashabiah son of Kemuel\n\\lf This was the list of the administrators of the tribes of Israel.\n\\v 7 in company with Zerubbabel, Jeshua, Nehemiah, Azariah, Raamiah, Nahamani, Mordecai,Bilshan, Mispereth, Bigvai, Nehum and Baanah):\n\\b\n\\pm The list of the men of Israel:\n\\b\n\\lim1\n\\v 8 the descendants of Parosh - \\litl 2,172\\litl*\n\\lim1\n\\v 9 of Shephatiah - \\litl 372\\litl*\n';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('table Markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\usfm 3.0\n\\toc1 The Acts of the Apostles\n\\toc2 Acts\n\\ip One of these brothers, Joseph, had become...\n\\ipr (50.24)\n\\c 136\n\\p\n\\v 12-83 They presented their offerings in the following order:\n\\tr \\th1 Day \\th2 Tribe \\thr3 Leader\n\\tr \\tcr1 1st \\tc2 Judah \\tcr3 Nahshon son of Amminadab\n\\tr \\tcr1 2nd \\tc2 Issachar \\tcr3 Nethanel son of Zuar\n\\tr \\tcr1 3rd \\tc2 Zebulun \\tcr3 Eliab son of Helon\n\\tr \\tcr1 4th \\tc2 Reuben \\tcr3 Elizur son of Shedeur\n\\tr \\tcr1 5th \\tc2 Simeon \\tcr3 Shelumiel son of Zurishaddai';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Footnote Markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\c 136\n\\s1 The Preaching of John the Baptist\n\\r (Matthew 3.1-12; Luke 3.1-18; John 1.19-28)\n\\p\n\\v 1 This is the Good News about Jesus Christ, the Son of God. \\f + \\fr 1.1: \\ft Some manuscripts do not have \\fq the Son of God.\\f*\n\\v 20 Adam \\f + \\fr 3.20: \\fk Adam: \\ft This name in Hebrew means “all human beings.”\\f* named his wife Eve, \\f + \\fr 3.20: \\fk Eve: \\ft This name sounds similar to the Hebrew word for “living,” which is rendered in this context as “human beings.”\\f* because she was the mother of all human beings.\n\\v 38 whoever believes in me should drink. As the scripture says, ‘Streams of life-giving water will pour out from his side.’” \\f + \\fr 7.38: \\ft Jesus\' words in verses 37-38 may be translated: \\fqa “Whoever is thirsty should come to me and drink. \\fv 38\\fv* As the scripture says, ‘Streams of life-giving water will pour out ...’”\\f*\n\\v 3 Él es el resplandor glorioso de Dios,\\f c \\fr 1.3: \\fk Resplandor: \\ft Cf. Jn 1.4-9,14\\fdc ; también Sab 7.25-26, donde algo parecido se dice de la sabiduría.\\f* la imagen misma ...';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Cross-reference Markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\c 6\n\\p\\v 18 “Why do you call me good?” Jesus asked him. “No one is good except God alone.\n\\v 19 \\x - \\xo 10.19: a \\xt Exo 20.13; Deu 5.17; \\xo b \\xt Exo 20.14; Deu 5.18; \\xo c \\xt Exo 20.15; Deu 5.19; \\xo d \\xt Exo 20.16; Deu 5.20; \\xo e \\xt Exo 20.12; Deu 5.16.\\x* You know the commandments: ‘Do not commit murder...\n\\c 2\n\\cd \\xt 1|GEN 2:1\\xt* Бог благословляет седьмой день; \\xt 8|GEN 2:8\\x* человек в раю Едемском; четыре реки; дерево познания добра и зла. \\xt 18|GEN 2:18\\x* Человек дает названия животным. \\xt 21|GEN 2:21\\xt* Создание женщины.\n\\p\n\\v 1 Так совершены небо и земля и все воинство их.\n\\c 3\n\\s1 The Preaching of John the Baptist\\x - \\xo 3.0 \\xta Compare with \\xt Mk 1.1-8; Lk 3.1-18; \\xta and \\xt Jn 1.19-28 \\xta parallel passages.\\x*\n\\p\n\\v 1 At that time John the Baptist came to...\n\\v 2 \\x - \\xo 1:1 \\xop Гл 1. (1)\\xop* \\xt 4 Царств. 14:25.\\x*И биде слово Господне към Иона, син Аматиев:\n\\v 3 Our God is in heaven;\n\\q2 he does whatever he wishes.\n\\q1\n\\v 4 \\x - \\xo 115.4-8: \\xt Ps 135.15-18; \\xdc Ltj Jr 4-73; \\xt Rev 9.20.\\x* Their gods are made of silver and gold,';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Word and Character Markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\is Introduction\n\\ip \\bk The Acts of the Apostles\\bk* is a continuation of \\bk The Gospel according to Luke\\bk* Its chief purpose is...\n\\c 6\n\\p \\v 14 That is why \\bk The Book of the \\+nd Lord\\+nd*\'s Battles\\bk* speaks of “...the town of Waheb in the area of ...\n\\v 15 and the slope of the valleys ...\n\\s1 The Garden of Eden\n\\p When the \\nd Lord\\nd* \\f + \\fr 2.4: \\fk the \\+nd Lord\\+nd*: \\ft Where the Hebrew text has Yahweh, traditionally transliterated as Jehovah, this translation employs \\+nd Lord\\+nd* with capital letters, following a usage which is widespread in English versions.\\f* God made the universe,\n\\v 5 there were no plants on the earth and no seeds had sprouted, because he had not sent any rain, and there was no one to cultivate the land;\n\\p\n\\v 29 И нарек ему имя: Ной, сказав: он утешит нас в работе нашей и в трудах рук наших при \\add возделывании\\add* земли, которую проклял Господь.\n\\v 3 Él es el resplandor glorioso de Dios,\\f c \\fr 1.3: \\fk Resplandor: \\ft Cf. Jn 1.4-9,14\\+dc ; también Sab 7.25-26, donde algo parecido se dice de la sabiduría\\+dc*.\\f* la imagen misma de\n\\v 9 От Господа спасение. Над народом Твоим благословение Твое.\n\\lit Слава:\n\\v 15 Tell the Israelites that I, the \\nd Lord\\nd*, the God...\n\\v 2 It began as the prophet Isaiah had written:\n\\q1 \\qt “God said, ‘I will send my messenger ahead of you\\qt*\n\\q2 \\qt to open the way for you.’\\qt*\n\\v 18 With my own hand I write this: \\sig Greetings from Paul\\sig*. Do not...\n\\v 8 \\sls Rehoum, chancelier, et Shimshaï, secrétaire, écrivirent au roi Artaxerxès la lettre suivante concernant Jérusalem, savoir:\\sls*\n\\c 9\n\\p \n\\s1 Jesus Heals a Man // Who Could Not Walk\n\\r (Mark 2.1-12; Luke 5.17-26)\n\\v 46 At about three o\'clock Jesus cried out with a loud shout, \\tl “Eli, Eli, lema sabachthani?”\\tl* which means, “My God, my God, why did you \n\\v 18 At once they left their nets and went with him.\\fig At once they left their nets.|src="avnt016.jpg" size="span" ref="1.18"\\fig*';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Markers with attributes, links and extended content markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\c 1\n\\p \\v 1 \n\\q1 “Someone is shouting in the desert,\n\\q2 ‘Prepare a road for the Lord;\n\\q2 make a straight path for him to travel!’ ”\n\\esb \\cat People\\cat*\n\\ms \\jmp |link-id="article-john_the_baptist"\\jmp*John the Baptist\n\\p John is sometimes called the last “Old Testament prophet” because of the warnings he brought about God\'s judgment and because he announced the coming of God\'s “Chosen One” (Messiah).\n\\esbe\n\\p \n\\v 2-6 From Abraham to King David, the following ancestors are listed: Abraham,...mother was \\jmp Ruth|link-href="#article-Ruth"\\jmp*), Jesse, and King David.\n\\w gracious|link-href="http://bibles.org/search/grace/eng-GNTD/all"\\w*';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+
+  it('Milestone markers', () => {
+    const inputUsfm = '\\id MAT 41MATGNT92.SFM, Good News Translation, June 2003\n\\c 1\\p \n\\v 1 \n\\q1 “Someone is shouting in the desert,\n\\qt-s |sid="qt_123" who="Pilate"\\*“Are you the king of the Jews?”\\qt-e |eid="qt_123"\\*\n\\zms\\*\n\\v 11 Jesus stood before the Roman governor, who questioned him. \\qt-s |who="Pilate"\\*“Are you the king of the Jews?”\\qt-e\\* he asked.\n\\p \\qt-s |who="Jesus"\\*“So you say,”\\qt-e\\* answered Jesus.\n\\v 12 But he said nothing in response to the accusations of the chief priests and elders.\n\\p\n\\v 13 So Pilate said to him, \\qt-s |who="Pilate"\\*“Don\'t you hear all these things they accuse you of?”\\qt-e\\*\n\\p\n\\v 14 But Jesus refused to answer ...\n\\ts\\*\n\\p\n\\v 5 Now I wish to remind you, although...\n\\ts-s|sid="ts_JUD_5-6"\\*\n\\p\n\\v 5 Now I wish to remind you, although you know everything, that the Lord once saved a\npeople out of the land of Egypt, but that afterward he destroyed those who did not believe.\n\\v 6 And angels who did not keep to their own principality, but left their proper dwelling\nplace—God has kept them in everlasting chains in darkness for the judgment of the\ngreat day.\n\\ts-e|eid="ts_JUD_5-6"\\*';
+
+    usfmConvertedJsonValidatorTest(inputUsfm);
+  });
+});
+
+describe('JSON validation: with invalid JSON', () => {
+  it('Empty JSON', () => {
+    const inputJson = {};
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('No bookCode in book', () => {
+    const inputJson = {
+      book: { description: 'some text' },
+      chapters: [{
+        chapterNumber: '3',
+        contents: [{ p: null },
+          {
+            verseNumber: '1',
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('Incorrect bookCode in book', () => {
+    const inputJson = {
+      book: { bookCode: 'genesis' },
+      chapters: [{
+        chapterNumber: '3',
+        contents: [{ p: null },
+          {
+            verseNumber: '1',
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('No chapter number', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{
+        contents: [{ p: null },
+          {
+            verseNumber: '1',
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('No verse number', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{
+        chapterNumber: '3',
+        contents: [{ p: null },
+          {
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('Verse number as integer', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{
+        chapterNumber: '3',
+        contents: [{ p: null },
+          {
+            verseNumber: 1,
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('Chapter number as integer', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{
+        chapterNumber: 3,
+        contents: [{ p: null },
+          {
+            verseNumber: '1',
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('No verseText in one verse', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{
+        chapterNumber: '3',
+        contents: [{ p: null },
+          {
+            verseNumber: '1',
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+          { verseNumber: '2' },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('No Contents in a chapter', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{ chapterNumber: '3' },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
+  });
+
+  it('Paragraph element outside of chapter-contents', () => {
+    const inputJson = {
+      book: { bookCode: 'GEN' },
+      chapters: [{
+        chapterNumber: '3',
+        p: null,
+        contents: [{ p: null },
+          {
+            verseNumber: '1',
+            verseText: 'This is a prayer of the prophet Habakkuk:',
+            contents: ['This is a prayer of the prophet Habakkuk:'],
+          },
+        ],
+      },
+      ],
+    };
+    jsonValidatorNegativeTest(inputJson);
   });
 });

--- a/test/test_bugFixes.js
+++ b/test/test_bugFixes.js
@@ -211,4 +211,24 @@ describe('Test bug fixes', () => {
     const jsonOutput = usfmParser.toJSON();
     assert.strictEqual(jsonOutput._messages._warnings.includes('Consecutive use of empty paragraph markers. '), false);
   });
+
+  it('replace ~ with \\u00A0', () => {
+    // ~ is included in USFM text to indicate No-break space. Replace it with actual
+    // no-break-space when encountered in input USFM text and do the reverse in JSON.
+    // https://github.com/Bridgeconn/usfm-grammar/issues/61
+    const inputUsfm = '\\id GEN\n\\c 1\n\\p\n\\v 1 verse text~with space';
+    const usfmParser = new grammar.USFMParser(inputUsfm);
+    const jsonOutput = usfmParser.toJSON();
+    assert.strictEqual(jsonOutput.chapters[0].contents[1].verseText, 'verse text\u00A0with space');
+    const jsonParser = new grammar.JSONParser(jsonOutput);
+    const reCreatedUsfm1 = jsonParser.toUSFM();
+    assert.strictEqual(reCreatedUsfm1, inputUsfm);
+
+    const relaxedUsfmParser = new grammar.USFMParser(inputUsfm);
+    const relaxedJsonOutput = relaxedUsfmParser.toJSON();
+    assert.strictEqual(relaxedJsonOutput.chapters[0].contents[1].verseText, 'verse text\u00A0with space');
+    const jsonParser2 = new grammar.JSONParser(relaxedJsonOutput);
+    const reCreatedUsfm2 = jsonParser2.toUSFM();
+    assert.strictEqual(reCreatedUsfm2, inputUsfm);
+  });
 });

--- a/test/test_bugFixes.js
+++ b/test/test_bugFixes.js
@@ -171,4 +171,34 @@ describe('Test bug fixes', () => {
     assert.deepStrictEqual(jsonOutput.chapters[0].contents[1].contents[1],
       { list: [{ li: null }] });
   });
+
+  it('warning for consecutive empty paragraph markers at chapter start', () => {
+    // As paragraph markers are used for setting a style to the text content that follows it
+    // using it consecutively does not create any impact in rendering USFM. So warn such usage
+    // https://github.com/Bridgeconn/usfm-grammar/issues/45
+    const inputUsfm = '\\id GEN\n\\c 1\n\\p\n\\b\n\\m\\v 1 verse text';
+    const usfmParser = new grammar.USFMParser(inputUsfm);
+    const jsonOutput = usfmParser.toJSON();
+    assert.strictEqual(jsonOutput._messages._warnings.includes('Consecutive use of empty paragraph markers. '), true);
+  });
+
+  it('warning for consecutive empty paragraph markers within a verse', () => {
+    // As paragraph markers are used for setting a style to the text content that follows it
+    // using it consecutively does not create any impact in rendering USFM. So warn such usage
+    // https://github.com/Bridgeconn/usfm-grammar/issues/45
+    const inputUsfm = '\\id GEN\n\\c 1\n\\p\n\\v 1 verse text\\p\n\\q some poetic text';
+    const usfmParser = new grammar.USFMParser(inputUsfm);
+    const jsonOutput = usfmParser.toJSON();
+    assert.strictEqual(jsonOutput._messages._warnings.includes('Consecutive use of empty paragraph markers. '), true);
+  });
+
+  it('no warning in the absence of consecutive empty paragraph markers', () => {
+    // As paragraph markers are used for setting a style to the text content that follows it
+    // using it consecutively does not create any impact in rendering USFM. So warn such usage
+    // https://github.com/Bridgeconn/usfm-grammar/issues/45
+    const inputUsfm = '\\id GEN\n\\c 1\n\\p\n\\v 1 verse text';
+    const usfmParser = new grammar.USFMParser(inputUsfm);
+    const jsonOutput = usfmParser.toJSON();
+    assert.strictEqual(jsonOutput._messages._warnings.includes('Consecutive use of empty paragraph markers. '), false);
+  });
 });

--- a/test/test_bugFixes.js
+++ b/test/test_bugFixes.js
@@ -172,6 +172,16 @@ describe('Test bug fixes', () => {
       { list: [{ li: null }] });
   });
 
+  it('warning for empty \\li marker', () => {
+    // li, lf and lh markers were defined so that it takes text.
+    // Now upadted it to allow empty list makers too. But gives a warning for empty usage.
+    // https://github.com/Bridgeconn/usfm-grammar/issues/84
+    const inputUsfm = '\\id GEN\n\\c 1\n\\p\n\\li\n\\v 1 verse text';
+    const usfmParser = new grammar.USFMParser(inputUsfm);
+    const jsonOutput = usfmParser.toJSON();
+    assert.strictEqual(jsonOutput._messages._warnings.includes('\\li used without content'), true);
+  });
+
   it('warning for consecutive empty paragraph markers at chapter start', () => {
     // As paragraph markers are used for setting a style to the text content that follows it
     // using it consecutively does not create any impact in rendering USFM. So warn such usage


### PR DESCRIPTION
- schema/file.js with the JSON schema definition. The schema available for user as `grammar.JSONSchemaDefinition`. (#74)
- JSONParser.validate() method to validate input JSON, just like we have USFMParser.validate()
- Internally we perform JSON validation before JSONParser.toUSFM(), JSONParser.toCSV() and JSONParser.toTSV() methods. Here proper error reporting is done, instead of parsing failing or giving `undefined` in output (#80)
- Added test cases for JSON validation 

Also in this PR
- give warnings for consecutive empty paragraph markers(#45)
- give warning for empty list markers(#84)
- converts ~ in USFM to no-break-space in JSON and vice-versa in reverse parsing(#61)