### PR TITLE
Add tests for CLI mode

### DIFF
--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup node and npm
         uses: actions/setup-node@v1
+        with:
+          node-version: 13.12.0
       - name: install packages
         run: npm install .
       # Runs the Linter action

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 13.12.0
       - run: npm ci
       - run: npm run test-on-github
 
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 13.12.0
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish

--- a/cli.js
+++ b/cli.js
@@ -13,8 +13,6 @@ const { argv } = require('yargs')
   .choices('filter', ['scripture'])
   .describe('format', 'specifies the output file format')
   .choices('format', ['csv', 'tsv', 'usfm', 'json'])
-  .alias('o', 'output')
-  .describe('o', 'specify the fully qualified file path for output.')
   .alias('h', 'help')
   .alias('v', 'version')
   .help('help');
@@ -73,18 +71,4 @@ if (argv.format === 'usfm' || isJson) {
   }
 }
 
-if (Object.prototype.hasOwnProperty.call(argv, 'o') || Object.prototype.hasOwnProperty.call(argv, 'output')) {
-  let filePath = argv.o;
-  if (!filePath) {
-    filePath = argv.output;
-  }
-  try {
-    fs.writeFileSync(filePath, output);
-  } catch (e) {
-    console.error('Error writting output file');
-    console.error(e.message);
-    process.exit(1);
-  }
-} else {
-  console.log(output);
-}
+console.log(output);

--- a/js/USFMparser.js
+++ b/js/USFMparser.js
@@ -137,6 +137,10 @@ class USFMParser extends Parser {
 
   toCSV() {
     const jsonOutput = this.toJSON();
+    if (Object.keys(jsonOutput).includes('_messages')
+      && Object.keys(jsonOutput._messages).includes('_error')) {
+      return jsonOutput;
+    }
     const myJsonParser = new JSONParser(jsonOutput);
     const csvOutput = myJsonParser.toCSV();
     return csvOutput;
@@ -144,6 +148,10 @@ class USFMParser extends Parser {
 
   toTSV() {
     const jsonOutput = this.toJSON();
+    if (Object.keys(jsonOutput).includes('_messages')
+      && Object.keys(jsonOutput._messages).includes('_error')) {
+      return jsonOutput;
+    }
     const myJsonParser = new JSONParser(jsonOutput);
     const csvOutput = myJsonParser.toTSV();
     return csvOutput;

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,8 @@
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
         },
         "callsites": {
             "version": "3.1.0",
@@ -335,6 +336,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
             "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -954,7 +956,8 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
         },
         "is-arguments": {
             "version": "1.0.4",
@@ -1712,6 +1715,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -1771,7 +1775,8 @@
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
         },
         "semver": {
             "version": "7.3.2",
@@ -1910,6 +1915,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             }
@@ -2000,7 +2006,8 @@
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
         },
         "uri-js": {
             "version": "4.2.2",
@@ -2014,7 +2021,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "util-extend": {
             "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "usfm-grammar",
-    "version": "2.0.0-beta.6",
+    "version": "2.0.0-beta.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -193,6 +193,11 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -325,6 +330,17 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
         },
         "confusing-browser-globals": {
             "version": "1.0.9",
@@ -938,8 +954,7 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "is-arguments": {
             "version": "1.0.4",
@@ -1693,6 +1708,16 @@
                 "read-pkg": "^2.0.0"
             }
         },
+        "readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            }
+        },
         "readdirp": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
@@ -1746,8 +1771,7 @@
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "semver": {
             "version": "7.3.2",
@@ -1882,6 +1906,14 @@
                 "es-abstract": "^1.17.5"
             }
         },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "strip-ansi": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -1965,6 +1997,11 @@
             "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "dev": true
         },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1973,6 +2010,11 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util-extend": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "test-on-github": "mocha --expose-gc --timeout 40000 --ignore test/test_filesFromWild.js --ignore test/test_cli.js"
     },
     "dependencies": {
-        "concat-stream": "^2.0.0",
         "jsonschema": "^1.4.0",
         "ohm-js": "^15.2.1",
         "yargs": "^16.0.3"
@@ -35,6 +34,7 @@
     },
     "homepage": "https://github.com/Bridgeconn/usfm-grammar",
     "devDependencies": {
+        "concat-stream": "^2.0.0",
         "eslint": "^7.7.0",
         "eslint-config-airbnb-base": "^14.2.0",
         "eslint-plugin-import": "^2.22.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "test-on-github": "mocha --expose-gc --timeout 40000 --ignore test/test_filesFromWild.js"
     },
     "dependencies": {
+        "concat-stream": "^2.0.0",
         "jsonschema": "^1.4.0",
         "ohm-js": "^15.2.1",
         "yargs": "^16.0.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "test": "mocha --expose-gc --timeout 40000",
         "start": "node ../server.js",
         "lint": "eslint .",
-        "test-on-github": "mocha --expose-gc --timeout 40000 --ignore test/test_filesFromWild.js"
+        "test-on-github": "mocha --expose-gc --timeout 40000 --ignore test/test_filesFromWild.js --ignore test/test_cli.js"
     },
     "dependencies": {
         "concat-stream": "^2.0.0",

--- a/test/resources/small.json
+++ b/test/resources/small.json
@@ -1,0 +1,40 @@
+{
+  "book": {
+    "bookCode": "GEN",
+    "description": "A small sample usfm file"
+  },
+  "chapters": [
+    {
+      "chapterNumber": "1",
+      "contents": [
+        {
+          "p": null
+        },
+        {
+          "verseNumber": "1",
+          "verseText": "one verse",
+          "contents": [
+            "one verse"
+          ]
+        },
+        {
+          "verseNumber": "2",
+          "verseText": "second verse",
+          "contents": [
+            "second verse"
+          ]
+        },
+        {
+          "verseNumber": "3",
+          "verseText": "final verse",
+          "contents": [
+            "final verse"
+          ]
+        }
+      ]
+    }
+  ],
+  "_messages": {
+    "_warnings": []
+  }
+}

--- a/test/resources/small.usfm
+++ b/test/resources/small.usfm
@@ -1,0 +1,6 @@
+\id GEN A small sample usfm file
+\c 1
+\p
+\v 1 one verse
+\v 2 second verse
+\v 3 final verse

--- a/test/resources/small1.json
+++ b/test/resources/small1.json
@@ -1,0 +1,40 @@
+{
+  "book": {
+    "bookCode": "GEN",
+    "description": "A small sample usfm file"
+  },
+  "chapters": [
+    {
+      "chapterNumber": "1",
+      "contents": [
+        {
+          "p": null
+        },
+        {
+          "verseNumber": "1",
+          "verseText": "one verse",
+          "contents": [
+            "one verse"
+          ]
+        },
+        {
+          "verseNumber": "2",
+          "verseText": "second verse",
+          "contents": [
+            "second verse"
+          ]
+        },
+        {
+          "verseNumber": "3",
+          "verseText": "final verse",
+          "contents": [
+            "final verse"
+          ]
+        }
+      ]
+    }
+  ],
+  "_messages": {
+    "_warnings": []
+  }
+}

--- a/test/resources/small2.json
+++ b/test/resources/small2.json
@@ -1,0 +1,40 @@
+{
+  "book": {
+    "bookCode": "GEN",
+    "description": "A small sample usfm file"
+  },
+  "chapters": [
+    {
+      "chapterNumber": "1",
+      "contents": [
+        {
+          "p": null
+        },
+        {
+          "verseNumber": "1",
+          "verseText": "one verse",
+          "contents": [
+            "one verse"
+          ]
+        },
+        {
+          "verseNumber": "2",
+          "verseText": "second verse",
+          "contents": [
+            "second verse"
+          ]
+        },
+        {
+          "verseNumber": "3",
+          "verseText": "final verse",
+          "contents": [
+            "final verse"
+          ]
+        }
+      ]
+    }
+  ],
+  "_messages": {
+    "_warnings": []
+  }
+}

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -1,0 +1,258 @@
+const { spawn } = require('child_process');
+const concat = require('concat-stream');
+const { EOL } = require('os');
+const assert = require('assert');
+
+
+function createProcess(args = [], env = null) {
+  // args = [processPath].concat(args);
+
+  return spawn('usfm-grammar', args, {
+    env: Object.assign(
+      {
+        NODE_ENV: 'test'
+      },
+      env
+    )
+  });
+}
+
+function execute(processPath, args = [], opts = {}) {
+  const { env = null } = opts;
+  const childProcess = createProcess(args, env);
+  childProcess.stdin.setEncoding('utf-8');  
+  const promise = new Promise((resolve, reject) => {
+    childProcess.stderr.once('data', err => {
+      reject(err.toString());
+    });    
+    childProcess.on('error', reject);    
+    childProcess.stdout.pipe(
+      concat(result => {
+        resolve(result.toString());
+      })
+    );
+  });
+  return promise;
+}
+
+
+describe('version and help', () => {
+  it('version with --version', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['--version']
+    );
+    const versionPattern = new RegExp('^\\d\\.\\d\\.\\d.*', 'g');
+    assert.match(response, versionPattern);
+  });
+
+  it('version with -v', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['-v']
+    );
+    const versionPattern = new RegExp('^\\d\\.\\d\\.\\d.*', 'g');
+    assert.match(response, versionPattern);
+  });
+
+  it('No arg', async () => {
+  	let thrownError = false;
+  	try {
+	    const response = await execute(
+	      'usfm-grammar',
+	      []
+	    );
+  	} catch (err){
+  		thrownError = true;
+  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+	    assert.match(err, helpPattern);
+  	}
+  	assert.strictEqual(thrownError, true);
+  });
+
+  it('Wrong argument', async () => {
+  	let thrownError = false;
+  	try {
+	    const response = await execute(
+	      'usfm-grammar',
+	      ['-f']
+	    );
+  	} catch (err){
+  		thrownError = true;
+  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+	    assert.match(err, helpPattern);
+  	}
+  	assert.strictEqual(thrownError, true)
+  });
+
+
+  it('help with -h', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['-h']
+    );
+    const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+    assert.match(response, helpPattern);
+  });
+
+  it('help with --help', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['--help']
+    );
+    const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+    assert.match(response, helpPattern);
+  });
+
+});
+
+describe('USFM parsing', () => {
+  it('one file argument', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm']
+    );
+    jsonObj = JSON.parse(response);
+    assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
+    assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
+  });
+
+  it('with invalid file', async () => {
+    const response = await execute(
+	      'usfm-grammar',
+	      ['./test/test.js']
+	    );
+    const jsonObj = JSON.parse(response)
+    assert.strictEqual(Object.keys(jsonObj).includes('_messages'), true);
+    assert.strictEqual(Object.keys(jsonObj._messages).includes('_error'), true);
+  });
+
+  it('level relaxed, with --level=relaxed', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '--level=relaxed']
+    );
+    jsonObj = JSON.parse(response);
+    assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
+    assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
+  });
+
+  it('level relaxed,  with -l relaxed', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '-l', 'relaxed']
+    );
+    jsonObj = JSON.parse(response);
+    assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
+    assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
+  });
+
+  it('level relaxed, with --level relaxed', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '--level', 'relaxed']
+    );
+    jsonObj = JSON.parse(response);
+    assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
+    assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
+  });
+
+  it('level, without value', async () => {
+  	let thrownError = false;
+  	try {
+	    const response = await execute(
+	      'usfm-grammar',
+	      ['--level']
+	    );
+  	} catch (err){
+  		thrownError = true;
+  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+	    assert.match(err, helpPattern);
+  	}
+  	assert.strictEqual(thrownError, true);
+  });
+
+  it('scripture filtered, with --filter scripture', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '--filter', 'scripture']
+    );
+    jsonObj = JSON.parse(response);
+    assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
+    assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
+  });
+
+  it('filter with wrong value', async () => {
+  	let thrownError = false;
+  	try {
+	    const response = await execute(
+	      'usfm-grammar',
+	      ['./test/resources/small.usfm', '--level', 'bible']
+	    );
+  	} catch (err){
+  		thrownError = true;
+  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+	    assert.match(err, helpPattern);
+  	}
+  	assert.strictEqual(thrownError, true)
+  });
+
+  it('both filter and level arguments', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '--filter', 'scripture', '--level', 'relaxed']
+    );
+    jsonObj = JSON.parse(response);
+    assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
+    assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
+  });
+
+  it('output file specified, with -o', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '-o', './test/resources/small1.json']
+    );
+    assert.strictEqual(response, '');
+  });
+
+  it('output file specified, with --output file-name', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '--output', './test/resources/small2.json']
+    );
+    assert.strictEqual(response, '');
+  });
+
+  it('output format specified, with --format==csv', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.usfm', '--format=csv']
+    );
+    const csvPattern = new RegExp('Book, Chapter, Verse, Text\n.*', 'g');
+    assert.match(response, csvPattern);
+  });
+
+
+});
+
+describe('JSON parsing', () => {
+  it('with one json file-path', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.json']
+    );
+    const usfmPattern = new RegExp('^\\\\id GEN A small sample usfm file\n.*', 'g');
+    assert.match(response, usfmPattern);
+  });
+
+  it('with additional arguments', async () => {
+    const response = await execute(
+      'usfm-grammar',
+      ['./test/resources/small.json', '--filter', 'scripture']
+    );
+    const usfmPattern = new RegExp('^\\\\id GEN A small sample usfm file\n.*', 'g');
+    assert.match(response, usfmPattern);
+  });
+
+
+});

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -1,46 +1,41 @@
 const { spawn } = require('child_process');
 const concat = require('concat-stream');
-const { EOL } = require('os');
 const assert = require('assert');
-
 
 function createProcess(args = [], env = null) {
   // args = [processPath].concat(args);
 
   return spawn('usfm-grammar', args, {
-    env: Object.assign(
-      {
-        NODE_ENV: 'test'
-      },
-      env
-    )
+    env: {
+      NODE_ENV: 'test',
+      ...env,
+    },
   });
 }
 
 function execute(processPath, args = [], opts = {}) {
   const { env = null } = opts;
   const childProcess = createProcess(args, env);
-  childProcess.stdin.setEncoding('utf-8');  
+  childProcess.stdin.setEncoding('utf-8');
   const promise = new Promise((resolve, reject) => {
-    childProcess.stderr.once('data', err => {
+    childProcess.stderr.once('data', (err) => {
       reject(err.toString());
-    });    
-    childProcess.on('error', reject);    
+    });
+    childProcess.on('error', reject);
     childProcess.stdout.pipe(
-      concat(result => {
+      concat((result) => {
         resolve(result.toString());
-      })
+      }),
     );
   });
   return promise;
 }
 
-
 describe('version and help', () => {
   it('version with --version', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['--version']
+      ['--version'],
     );
     const versionPattern = new RegExp('^\\d\\.\\d\\.\\d.*', 'g');
     assert.match(response, versionPattern);
@@ -49,80 +44,78 @@ describe('version and help', () => {
   it('version with -v', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['-v']
+      ['-v'],
     );
     const versionPattern = new RegExp('^\\d\\.\\d\\.\\d.*', 'g');
     assert.match(response, versionPattern);
   });
 
   it('No arg', async () => {
-  	let thrownError = false;
-  	try {
-	    const response = await execute(
-	      'usfm-grammar',
-	      []
-	    );
-  	} catch (err){
-  		thrownError = true;
-  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
-	    assert.match(err, helpPattern);
-  	}
-  	assert.strictEqual(thrownError, true);
+    let thrownError = false;
+    try {
+      await execute(
+        'usfm-grammar',
+        [],
+      );
+    } catch (err) {
+      thrownError = true;
+      const helpPattern = new RegExp('^usfm-grammar <file-path>\\n.*', 'g');
+      assert.match(err, helpPattern);
+    }
+    assert.strictEqual(thrownError, true);
   });
 
   it('Wrong argument', async () => {
-  	let thrownError = false;
-  	try {
-	    const response = await execute(
-	      'usfm-grammar',
-	      ['-f']
-	    );
-  	} catch (err){
-  		thrownError = true;
-  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
-	    assert.match(err, helpPattern);
-  	}
-  	assert.strictEqual(thrownError, true)
+    let thrownError = false;
+    try {
+      await execute(
+        'usfm-grammar',
+        ['-f'],
+      );
+    } catch (err) {
+      thrownError = true;
+      const helpPattern = new RegExp('^usfm-grammar <file-path>\\n.*', 'g');
+      assert.match(err, helpPattern);
+    }
+    assert.strictEqual(thrownError, true);
   });
-
 
   it('help with -h', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['-h']
+      ['-h'],
     );
-    const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+    const helpPattern = new RegExp('^usfm-grammar <file-path>\\n.*', 'g');
     assert.match(response, helpPattern);
   });
 
   it('help with --help', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['--help']
+      ['--help'],
     );
-    const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
+    const helpPattern = new RegExp('^usfm-grammar <file-path>\\n.*', 'g');
     assert.match(response, helpPattern);
   });
-
 });
 
 describe('USFM parsing', () => {
   it('one file argument', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm']
+      ['./test/resources/small.usfm'],
     );
-    jsonObj = JSON.parse(response);
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
 
   it('with invalid file', async () => {
     const response = await execute(
-	      'usfm-grammar',
-	      ['./test/test.js']
-	    );
-    const jsonObj = JSON.parse(response)
+      'usfm-grammar',
+      ['./test/test.js'],
+    );
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('_messages'), true);
     assert.strictEqual(Object.keys(jsonObj._messages).includes('_error'), true);
   });
@@ -130,9 +123,9 @@ describe('USFM parsing', () => {
   it('level relaxed, with --level=relaxed', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '--level=relaxed']
+      ['./test/resources/small.usfm', '--level=relaxed'],
     );
-    jsonObj = JSON.parse(response);
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
@@ -140,9 +133,9 @@ describe('USFM parsing', () => {
   it('level relaxed,  with -l relaxed', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '-l', 'relaxed']
+      ['./test/resources/small.usfm', '-l', 'relaxed'],
     );
-    jsonObj = JSON.parse(response);
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
@@ -150,59 +143,59 @@ describe('USFM parsing', () => {
   it('level relaxed, with --level relaxed', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '--level', 'relaxed']
+      ['./test/resources/small.usfm', '--level', 'relaxed'],
     );
-    jsonObj = JSON.parse(response);
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
 
   it('level, without value', async () => {
-  	let thrownError = false;
-  	try {
-	    const response = await execute(
-	      'usfm-grammar',
-	      ['--level']
-	    );
-  	} catch (err){
-  		thrownError = true;
-  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
-	    assert.match(err, helpPattern);
-  	}
-  	assert.strictEqual(thrownError, true);
+    let thrownError = false;
+    try {
+      await execute(
+        'usfm-grammar',
+        ['--level'],
+      );
+    } catch (err) {
+      thrownError = true;
+      const helpPattern = new RegExp('^usfm-grammar <file-path>\\n.*', 'g');
+      assert.match(err, helpPattern);
+    }
+    assert.strictEqual(thrownError, true);
   });
 
   it('scripture filtered, with --filter scripture', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '--filter', 'scripture']
+      ['./test/resources/small.usfm', '--filter', 'scripture'],
     );
-    jsonObj = JSON.parse(response);
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
 
   it('filter with wrong value', async () => {
-  	let thrownError = false;
-  	try {
-	    const response = await execute(
-	      'usfm-grammar',
-	      ['./test/resources/small.usfm', '--level', 'bible']
-	    );
-  	} catch (err){
-  		thrownError = true;
-  		const helpPattern = new RegExp('^usfm-grammar <file-path>\n.*', 'g');
-	    assert.match(err, helpPattern);
-  	}
-  	assert.strictEqual(thrownError, true)
+    let thrownError = false;
+    try {
+      await execute(
+        'usfm-grammar',
+        ['./test/resources/small.usfm', '--level', 'bible'],
+      );
+    } catch (err) {
+      thrownError = true;
+      const helpPattern = new RegExp('^usfm-grammar <file-path>\\n.*', 'g');
+      assert.match(err, helpPattern);
+    }
+    assert.strictEqual(thrownError, true);
   });
 
   it('both filter and level arguments', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '--filter', 'scripture', '--level', 'relaxed']
+      ['./test/resources/small.usfm', '--filter', 'scripture', '--level', 'relaxed'],
     );
-    jsonObj = JSON.parse(response);
+    const jsonObj = JSON.parse(response);
     assert.strictEqual(Object.keys(jsonObj).includes('book'), true);
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
@@ -210,7 +203,7 @@ describe('USFM parsing', () => {
   it('output file specified, with -o', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '-o', './test/resources/small1.json']
+      ['./test/resources/small.usfm', '-o', './test/resources/small1.json'],
     );
     assert.strictEqual(response, '');
   });
@@ -218,7 +211,7 @@ describe('USFM parsing', () => {
   it('output file specified, with --output file-name', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '--output', './test/resources/small2.json']
+      ['./test/resources/small.usfm', '--output', './test/resources/small2.json'],
     );
     assert.strictEqual(response, '');
   });
@@ -226,33 +219,29 @@ describe('USFM parsing', () => {
   it('output format specified, with --format==csv', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.usfm', '--format=csv']
+      ['./test/resources/small.usfm', '--format=csv'],
     );
-    const csvPattern = new RegExp('Book, Chapter, Verse, Text\n.*', 'g');
+    const csvPattern = new RegExp('Book, Chapter, Verse, Text\\n.*', 'g');
     assert.match(response, csvPattern);
   });
-
-
 });
 
 describe('JSON parsing', () => {
   it('with one json file-path', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.json']
+      ['./test/resources/small.json'],
     );
-    const usfmPattern = new RegExp('^\\\\id GEN A small sample usfm file\n.*', 'g');
+    const usfmPattern = new RegExp('^\\\\id GEN A small sample usfm file\\n.*', 'g');
     assert.match(response, usfmPattern);
   });
 
   it('with additional arguments', async () => {
     const response = await execute(
       'usfm-grammar',
-      ['./test/resources/small.json', '--filter', 'scripture']
+      ['./test/resources/small.json', '--filter', 'scripture'],
     );
-    const usfmPattern = new RegExp('^\\\\id GEN A small sample usfm file\n.*', 'g');
+    const usfmPattern = new RegExp('^\\\\id GEN A small sample usfm file\\n.*', 'g');
     assert.match(response, usfmPattern);
   });
-
-
 });

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -200,22 +200,6 @@ describe('Test CLI: USFM parsing', () => {
     assert.strictEqual(Object.keys(jsonObj).includes('chapters'), true);
   });
 
-  it('output file specified, with -o', async () => {
-    const response = await execute(
-      'usfm-grammar',
-      ['./test/resources/small.usfm', '-o', './test/resources/small1.json'],
-    );
-    assert.strictEqual(response, '');
-  });
-
-  it('output file specified, with --output file-name', async () => {
-    const response = await execute(
-      'usfm-grammar',
-      ['./test/resources/small.usfm', '--output', './test/resources/small2.json'],
-    );
-    assert.strictEqual(response, '');
-  });
-
   it('output format specified, with --format==csv', async () => {
     const response = await execute(
       'usfm-grammar',

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -31,7 +31,7 @@ function execute(processPath, args = [], opts = {}) {
   return promise;
 }
 
-describe('version and help', () => {
+describe('Test CLI: version and help', () => {
   it('version with --version', async () => {
     const response = await execute(
       'usfm-grammar',
@@ -99,7 +99,7 @@ describe('version and help', () => {
   });
 });
 
-describe('USFM parsing', () => {
+describe('Test CLI: USFM parsing', () => {
   it('one file argument', async () => {
     const response = await execute(
       'usfm-grammar',
@@ -226,7 +226,7 @@ describe('USFM parsing', () => {
   });
 });
 
-describe('JSON parsing', () => {
+describe('Test CLI: JSON parsing', () => {
   it('with one json file-path', async () => {
     const response = await execute(
       'usfm-grammar',


### PR DESCRIPTION
Adds 20 testcases for CLI.

These tests are excluded when running on github actions. These tests require spawning child processes from node to run the terminal commands. This is running properly on local machine, but throwing error when run on github actions. Hence excluded them.

Also in this PR

- removes the output file option from CLI #98 
- report USFM errors properly in TSV and CSV conversions #97
- change the verseText creating code #99 