### PR TITLE
Error handling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -44,7 +44,7 @@ if (argv.format === 'usfm' || isJson) {
     output = myJsonParser.toUSFM(inputFile);
   } catch (e) {
     console.error('Error parsing the input JSON.');
-    console.error(e.message);
+    console.error(e);
     process.exit(1);
   }
 } else {
@@ -66,7 +66,7 @@ if (argv.format === 'usfm' || isJson) {
     }
   } catch (e) {
     console.error('Error parsing the input USFM.');
-    console.error(e.message);
+    console.error(e);
     process.exit(1);
   }
 }

--- a/js/USFMparser.js
+++ b/js/USFMparser.js
@@ -132,15 +132,11 @@ class USFMParser extends Parser {
       }
       return jsonOutput;
     }
-    return { _messages: { _error: matchObj.ERROR } };
+    throw matchObj.ERROR;
   }
 
   toCSV() {
     const jsonOutput = this.toJSON();
-    if (Object.keys(jsonOutput).includes('_messages')
-      && Object.keys(jsonOutput._messages).includes('_error')) {
-      return jsonOutput;
-    }
     const myJsonParser = new JSONParser(jsonOutput);
     const csvOutput = myJsonParser.toCSV();
     return csvOutput;
@@ -148,13 +144,9 @@ class USFMParser extends Parser {
 
   toTSV() {
     const jsonOutput = this.toJSON();
-    if (Object.keys(jsonOutput).includes('_messages')
-      && Object.keys(jsonOutput._messages).includes('_error')) {
-      return jsonOutput;
-    }
     const myJsonParser = new JSONParser(jsonOutput);
-    const csvOutput = myJsonParser.toTSV();
-    return csvOutput;
+    const tsvOutput = myJsonParser.toTSV();
+    return tsvOutput;
   }
 }
 

--- a/test/test_backward.js
+++ b/test/test_backward.js
@@ -27,11 +27,14 @@ function usfmConvertedJsonValidatorTest(inputUsfm) {
 function jsonValidatorNegativeTest(inputJson) {
   const jsonParser = new grammar.JSONParser(inputJson);
   const validity = jsonParser.validate();
-  const usfmOutput = jsonParser.toUSFM();
   assert.strictEqual(validity, false);
-  assert.strictEqual('_messages' in usfmOutput, true);
-  assert.strictEqual('_error' in usfmOutput._messages, true);
-  // console.log(usfmOutput._messages._error);
+  let thrownError = false;
+  try{
+    const usfmOutput = jsonParser.toUSFM();
+  } catch(err){
+    thrownError = true;
+  }
+  assert.strictEqual(thrownError, true);
 }
 
 beforeEach(() => {

--- a/test/test_backward.js
+++ b/test/test_backward.js
@@ -9,18 +9,12 @@ function usfmConvertedJsonValidatorTest(inputUsfm) {
   let jsonOutput = usfmParser.toJSON();
   let jsonParser = new grammar.JSONParser(jsonOutput);
   let validity = jsonParser.validate();
-  // if (validity === false) {
-  //   console.log(jsonParser.toUSFM())
-  // }
   assert(validity, true);
 
   usfmParser = new grammar.USFMParser(inputUsfm, grammar.LEVEL.RELAXED);
   jsonOutput = usfmParser.toJSON();
   jsonParser = new grammar.JSONParser(jsonOutput);
   validity = jsonParser.validate();
-  // if (validity === false) {
-  //   console.log(jsonParser.toUSFM())
-  // }
   assert(validity, true);
 }
 
@@ -29,9 +23,9 @@ function jsonValidatorNegativeTest(inputJson) {
   const validity = jsonParser.validate();
   assert.strictEqual(validity, false);
   let thrownError = false;
-  try{
-    const usfmOutput = jsonParser.toUSFM();
-  } catch(err){
+  try {
+    jsonParser.toUSFM();
+  } catch (err) {
     thrownError = true;
   }
   assert.strictEqual(thrownError, true);

--- a/test/test_bugFixes.js
+++ b/test/test_bugFixes.js
@@ -125,37 +125,37 @@ describe('Test bug fixes', () => {
     let inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തി പുസ്തകം\n\\c 1\n\\p\n\\v 1 ആദിയിൽ ദൈവം \\w ആകാശവും |lemma=ആകാശം strong="l" x-morph="He,R:Sp1cs"\\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     let usfmParser = new grammar.USFMParser(inputUsfm);
     let thrownError = false;
-    try{
-        let jsonOutput = usfmParser.toJSON();
+    try {
+      usfmParser.toJSON();
     } catch (err) {
-        thrownError = true
+      thrownError = true;
     }
     assert.strictEqual(thrownError, true);
     inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തി പുസ്തകം\n\\c 1\n\\p\n\\v 1 ആദിയിൽ ദൈവം \\w ആകാശവും |lemma= strong="l" x-morph="He,R:Sp1cs"\\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     usfmParser = new grammar.USFMParser(inputUsfm);
     thrownError = false;
-    try{
-        let jsonOutput = usfmParser.toJSON();
+    try {
+      usfmParser.toJSON();
     } catch (err) {
-        thrownError = true
+      thrownError = true;
     }
     assert.strictEqual(thrownError, true);
     inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തിപുസ്തകം\n\\c 1\n\\pi\n\\v 1 ആദിയിൽ ദൈവം \\w ആകാശവും |lemma strong="l" x-morph="He,R:Sp1cs"\\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     usfmParser = new grammar.USFMParser(inputUsfm);
     thrownError = false;
-    try{
-        let jsonOutput = usfmParser.toJSON();
+    try {
+      usfmParser.toJSON();
     } catch (err) {
-        thrownError = true
+      thrownError = true;
     }
     assert.strictEqual(thrownError, true);
     inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തിപുസ്തകം\n\\c 1\n\\pi\n\\v 6 ആദിയിൽ ദൈവം \\w ആകാശവും| \\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     usfmParser = new grammar.USFMParser(inputUsfm);
     thrownError = false;
-    try{
-        let jsonOutput = usfmParser.toJSON();
+    try {
+      usfmParser.toJSON();
     } catch (err) {
-        thrownError = true
+      thrownError = true;
     }
     assert.strictEqual(thrownError, true);
   });

--- a/test/test_bugFixes.js
+++ b/test/test_bugFixes.js
@@ -124,20 +124,40 @@ describe('Test bug fixes', () => {
     // https://github.com/Bridgeconn/usfm-grammar/issues/87
     let inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തി പുസ്തകം\n\\c 1\n\\p\n\\v 1 ആദിയിൽ ദൈവം \\w ആകാശവും |lemma=ആകാശം strong="l" x-morph="He,R:Sp1cs"\\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     let usfmParser = new grammar.USFMParser(inputUsfm);
-    let jsonOutput = usfmParser.toJSON();
-    assert.strictEqual('_error' in jsonOutput._messages, true);
+    let thrownError = false;
+    try{
+        let jsonOutput = usfmParser.toJSON();
+    } catch (err) {
+        thrownError = true
+    }
+    assert.strictEqual(thrownError, true);
     inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തി പുസ്തകം\n\\c 1\n\\p\n\\v 1 ആദിയിൽ ദൈവം \\w ആകാശവും |lemma= strong="l" x-morph="He,R:Sp1cs"\\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     usfmParser = new grammar.USFMParser(inputUsfm);
-    jsonOutput = usfmParser.toJSON();
-    assert.strictEqual('_error' in jsonOutput._messages, true);
+    thrownError = false;
+    try{
+        let jsonOutput = usfmParser.toJSON();
+    } catch (err) {
+        thrownError = true
+    }
+    assert.strictEqual(thrownError, true);
     inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തിപുസ്തകം\n\\c 1\n\\pi\n\\v 1 ആദിയിൽ ദൈവം \\w ആകാശവും |lemma strong="l" x-morph="He,R:Sp1cs"\\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     usfmParser = new grammar.USFMParser(inputUsfm);
-    jsonOutput = usfmParser.toJSON();
-    assert.strictEqual('_error' in jsonOutput._messages, true);
+    thrownError = false;
+    try{
+        let jsonOutput = usfmParser.toJSON();
+    } catch (err) {
+        thrownError = true
+    }
+    assert.strictEqual(thrownError, true);
     inputUsfm = '\\id GEN\n\\mt1 ഉല്പത്തിപുസ്തകം\n\\c 1\n\\pi\n\\v 6 ആദിയിൽ ദൈവം \\w ആകാശവും| \\w* ഭൂമിയും സൃഷ്ടിച്ചു.';
     usfmParser = new grammar.USFMParser(inputUsfm);
-    jsonOutput = usfmParser.toJSON();
-    assert.strictEqual('_error' in jsonOutput._messages, true);
+    thrownError = false;
+    try{
+        let jsonOutput = usfmParser.toJSON();
+    } catch (err) {
+        thrownError = true
+    }
+    assert.strictEqual(thrownError, true);
   });
 
   it('Line break between attributes', () => {

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -111,13 +111,18 @@ describe('Test CLI: USFM parsing', () => {
   });
 
   it('with invalid file', async () => {
-    const response = await execute(
-      'usfm-grammar',
-      ['./test/test.js'],
-    );
-    const jsonObj = JSON.parse(response);
-    assert.strictEqual(Object.keys(jsonObj).includes('_messages'), true);
-    assert.strictEqual(Object.keys(jsonObj._messages).includes('_error'), true);
+    let thrownError = false;
+    try {
+      await execute(
+        'usfm-grammar',
+        ['./test/test.js'],
+      );
+    } catch (err) {
+      thrownError = true;
+      const errPattern = new RegExp('^Error parsing the input USFM.*', 'g');
+      assert.match(err, errPattern);
+    }
+    assert.strictEqual(thrownError, true);
   });
 
   it('level relaxed, with --level=relaxed', async () => {


### PR DESCRIPTION
Updated the code so that, when parsing fails due to error in input file, now all conversion methods throws error, instead of returning a JSON with error message. 
The `USFMParser.validate()` and `JSONParser.validate()` methods still returns a `false` as before, for the presence of error in input, without throwing an error.

More details in #100 