### PR TITLE
JSON property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Try out the `usfm-grammar` based online convertor: https://usfm.vachanengine.org
 </td>
 </tr></table>
 
+The JSON structure confines to the schema defined [here](https://github.com/Bridgeconn/usfm-grammar/blob/master/schemas/file.js).
+
+The JSON uses the usfm marker names as property names along with some additional names as follows: book, bookCode, description, meta, chapters, contents, verseNumber, verseText, attributes, defaultAttribute, closing, footnote, endnote, extended-footnote, cross-ref, extended-cross-ref, caller(within notes), list, table, header(within table), milestone and namespace.
+
 ## Installation
 
 The parser is [available on NPM](https://www.npmjs.com/package/usfm-grammar) and can be installed by:
@@ -128,14 +132,25 @@ Then from the command line (terminal) to convert a valid USFM file into JSON (on
 
 ```
 > usfm-grammar -h
-  -v, --version     Show version number                                    [boolean]
-  -l, --level   specify the level of strictness in parsing  [choices: "relaxed"]
-  --filter      filters out only the specific contents from input USFM
-                                                          [choices: "scripture"]
-  --format      specifies the output file format
+usfm-grammar <file>
+
+Parse/validate USFM 3.x to/from JSON.
+
+Positionals:
+  file  The path of the USFM or JSON file to be parsed and/or converted. By
+        default, auto-detects input USFM and converts it into JSON and
+        vice-versa.
+
+Options:
+  -l, --level    Level of strictness in parsing. This defaults to `strict`.
+                                                            [choices: "relaxed"]
+      --filter   Filter out content from input USFM. Not applicable for input
+                 JSON or for CSV/TSV output.              [choices: "scripture"]
+  -o, --output   The output format to convert input into.
                                          [choices: "csv", "tsv", "usfm", "json"]
-  -o, --output  specify the fully qualified file path for output.
-  -h, --help    Show help 
+  -h, --help     Show help                                             [boolean]
+  -v, --version  Show version number                                   [boolean]
+
 ```
 The options `-l` (`--level`) and `--filter` do not have any effect if used for JSON to USFM conversion. 
 
@@ -172,7 +187,7 @@ The `relaxed` mode provides relaxation from checking several rules in the USFM s
 > _Caution:_
 > Errors may go unnoticed that might lead to loss of information when using the `relaxed` mode. For example, if the input USFM has erroneously does not have a space between the verse marker and the verse number (e.g. `\v3`)  the parser in `relaxed` mode would treat it as a separate marker (`v3` as opposed to `v`) and fail to recognise it is a verse. The right (or the hard) thing to do is fix the markup according to the specification. We generally recommend using the grammar in the default mode.
 
-#### Validate
+#### Validate USFM
 3) `USFMParser.validate()`
 
 ```
@@ -195,12 +210,20 @@ let reCreatedUsfm = myJsonParser.toUSFM();
 ```
 This method works with JSON output created with or without the `grammar.FILTER.SCRIPTURE` option. 
 
-#### USFM/JSON to CSV/TSV
-5) `USFMParser.toCSV()`
-6) `JSONParser.toCSV()`
+### Validate JSON
+5) `JSONParser.validate()`
 
-7) `USFMParser.toTSV()`
-8) `JSONParser.toTSV()`
+```
+// Returns a Boolean indicating whether the input JSON confines to grammar.JSONSchemaDefinition. 
+var isJsonValid = myJsonParser.validate();
+```
+
+#### USFM/JSON to CSV/TSV
+6) `USFMParser.toCSV()`
+7) `JSONParser.toCSV()`
+
+8) `USFMParser.toTSV()`
+9) `JSONParser.toTSV()`
 ```
 // Example usage:
 // Returns CSV and TSV from a USFM, respectively

--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -135,8 +135,8 @@ class JSONParser extends Parser {
             usfmText += ` \\${innerKey} ${jsonObject.table.rows[i][j][innerKey]}`;
           }
         }
-      } else if (key === 'footnote') {
-        const notes = jsonObject.footnote;
+      } else if (['footnote', 'endnote', 'extended-footnote'].includes(key)) {
+        const notes = jsonObject[key];
         const marker = jsonObject.closing;
         usfmText += marker.replace('*', '');
         for (let i = 0; i < notes.length; i += 1) {
@@ -144,8 +144,8 @@ class JSONParser extends Parser {
           if (innerKey === 'caller') { usfmText += notes[i][innerKey]; } else { usfmText = this.processInnerElements(notes[i], usfmText); }
         }
         usfmText += marker;
-      } else if (key === 'cross-ref') {
-        const notes = jsonObject['cross-ref'];
+      } else if (['cross-ref', 'extended-cross-ref'].includes(key)) {
+        const notes = jsonObject[key];
         const marker = jsonObject.closing;
         if (marker !== '\\xt*') { usfmText += marker.replace('*', ''); }
         for (let i = 0; i < notes.length; i += 1) {

--- a/js/grammarOperations.js
+++ b/js/grammarOperations.js
@@ -530,7 +530,7 @@ sem.addOperation('composeJson', {
     const contElmnts = content.composeJson();
     if (caller.sourceString !== '') { contElmnts.unshift({ caller: caller.sourceString }); }
     const obj = {
-      footnote: contElmnts,
+      endnote: contElmnts,
       closing: _6.sourceString + _7.sourceString + _8.sourceString,
     };
     return obj;
@@ -540,7 +540,7 @@ sem.addOperation('composeJson', {
     const contElmnts = content.composeJson();
     if (caller.sourceString !== '') { contElmnts.unshift({ caller: caller.sourceString }); }
     const obj = {
-      footnote: contElmnts,
+      'extended-footnote': contElmnts,
       closing: _6.sourceString + _7.sourceString + _8.sourceString,
     };
     return obj;
@@ -548,9 +548,11 @@ sem.addOperation('composeJson', {
 
   crossrefElement(nl, _2, tag, _4, caller, _5, content, _6, _7, _8) {
     const contElmnts = content.composeJson();
+    let marker = 'cross-ref';
     if (caller.sourceString !== '') { contElmnts.unshift({ caller: caller.sourceString }); }
+    if (tag.sourceString === 'ex') { marker = 'extended-cross-ref'; }
     const obj = {
-      'cross-ref': contElmnts,
+      [marker]: contElmnts,
       closing: _6.sourceString + _7.sourceString + _8.sourceString,
     };
     return obj;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "usfm-grammar",
     "description": "An elegant [USFM](https://github.com/ubsicap/usfm) parser (or validator) that uses a [parsing expression grammar](https://en.wikipedia.org/wiki/Parsing_expression_grammar) to model USFM. The grammar is written using [ohm](https://ohmlang.github.io/). Only USFM 3.0 is supported. The parsed USFM is an intuitive and easy to manipulate JSON structure that allows for painless extraction of scripture and other content from the markup. USFM Grammar is also capable of reconverting the generated JSON back to USFM.",
-    "version": "2.0.0-beta.7",
+    "version": "2.0.0-beta.8",
     "main": "./js/main.js",
     "scripts": {
         "test": "mocha --expose-gc --timeout 40000",


### PR DESCRIPTION
- uses property names footnote, endnote, extended-footnote, cross-ref and extended-cross-ref as per the appropriate tags, instead of calling them just footnote and  cross-ref.
- Document the list of key-words used in JSON structure in README
- Dcoument JSON validation api in README