### PR TITLE
fix spelling and space issues

### DIFF
--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -196,7 +196,7 @@ class JSONParser extends Parser {
     const jsonOutput = checkJSON(this.JSONObject);
     const bookName = jsonOutput.book.bookCode;
     const { chapters } = jsonOutput;
-    let csvWriter = 'Book, Chapter, Verse, Text\n';
+    let csvWriter = 'Book,Chapter,Verse,Text\n';
     for (let i = 0; i < chapters.length; i += 1) {
       const cno = chapters[i].chapterNumber;
       for (let j = 0; j < chapters[i].contents.length; j += 1) {

--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -196,7 +196,7 @@ class JSONParser extends Parser {
     const jsonOutput = checkJSON(this.JSONObject);
     const bookName = jsonOutput.book.bookCode;
     const { chapters } = jsonOutput;
-    let csvWriter = 'Book,Chapter,Verse,Text\n';
+    let csvWriter = '"Book","Chapter","Verse"\n';
     for (let i = 0; i < chapters.length; i += 1) {
       const cno = chapters[i].chapterNumber;
       for (let j = 0; j < chapters[i].contents.length; j += 1) {

--- a/js/JSONparser.js
+++ b/js/JSONparser.js
@@ -158,7 +158,7 @@ class JSONParser extends Parser {
         }
         usfmText += marker;
       } else if (key === 'milestone') {
-        usfmText += `\\${jsonObject.milestone}${jsonObject.delimter}`;
+        usfmText += `\\${jsonObject.milestone}${jsonObject.delimiter}`;
         if (Object.prototype.hasOwnProperty.call(jsonObject, 'attributes')) {
           usfmText += ' |';
           for (let i = 0; i < jsonObject.attributes.length; i += 1) {

--- a/js/grammarOperations.js
+++ b/js/grammarOperations.js
@@ -1168,7 +1168,7 @@ sem.addOperation('composeJson', {
   milestonePairElement(_1, _2, ms, sE, _5, _6, _7, attribs, _8) {
     const milestoneElement = {};
     milestoneElement.milestone = ms.sourceString;
-    milestoneElement.delimter = sE.sourceString;
+    milestoneElement.delimiter = sE.sourceString;
     milestoneElement.closing = _8.sourceString;
     if (attribs.sourceString !== '') {
       milestoneElement.attributes = attribs.composeJson();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "usfm-grammar",
     "description": "An elegant [USFM](https://github.com/ubsicap/usfm) parser (or validator) that uses a [parsing expression grammar](https://en.wikipedia.org/wiki/Parsing_expression_grammar) to model USFM. The grammar is written using [ohm](https://ohmlang.github.io/). Only USFM 3.0 is supported. The parsed USFM is an intuitive and easy to manipulate JSON structure that allows for painless extraction of scripture and other content from the markup. USFM Grammar is also capable of reconverting the generated JSON back to USFM.",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "main": "./js/main.js",
     "scripts": {
         "test": "mocha --expose-gc --timeout 40000",

--- a/test/test_apis.js
+++ b/test/test_apis.js
@@ -50,7 +50,7 @@ describe('API tests', () => {
     const usfmParser = new grammar.USFMParser(inputUSFM);
     const csvString = usfmParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book,Chapter,Verse'));
+    assert(csvString.startsWith('"Book","Chapter","Verse"'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -58,7 +58,7 @@ describe('API tests', () => {
     const usfmParser = new grammar.USFMParser(inputUSFM, grammar.LEVEL.RELAXED);
     const csvString = usfmParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book,Chapter,Verse'));
+    assert(csvString.startsWith('"Book","Chapter","Verse"'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -108,7 +108,7 @@ describe('API tests', () => {
     const jsonParser = new grammar.JSONParser(jsonObject);
     const csvString = jsonParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book,Chapter,Verse'));
+    assert(csvString.startsWith('"Book","Chapter","Verse"'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -118,7 +118,7 @@ describe('API tests', () => {
     const jsonParser = new grammar.JSONParser(jsonObject);
     const csvString = jsonParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book,Chapter,Verse'));
+    assert(csvString.startsWith('"Book","Chapter","Verse"'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -128,7 +128,7 @@ describe('API tests', () => {
     const jsonParser = new grammar.JSONParser(jsonObject);
     const csvString = jsonParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book,Chapter,Verse'));
+    assert(csvString.startsWith('"Book","Chapter","Verse"'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 

--- a/test/test_apis.js
+++ b/test/test_apis.js
@@ -50,7 +50,7 @@ describe('API tests', () => {
     const usfmParser = new grammar.USFMParser(inputUSFM);
     const csvString = usfmParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book, Chapter, Verse'));
+    assert(csvString.startsWith('Book,Chapter,Verse'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -58,7 +58,7 @@ describe('API tests', () => {
     const usfmParser = new grammar.USFMParser(inputUSFM, grammar.LEVEL.RELAXED);
     const csvString = usfmParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book, Chapter, Verse'));
+    assert(csvString.startsWith('Book,Chapter,Verse'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -108,7 +108,7 @@ describe('API tests', () => {
     const jsonParser = new grammar.JSONParser(jsonObject);
     const csvString = jsonParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book, Chapter, Verse'));
+    assert(csvString.startsWith('Book,Chapter,Verse'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -118,7 +118,7 @@ describe('API tests', () => {
     const jsonParser = new grammar.JSONParser(jsonObject);
     const csvString = jsonParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book, Chapter, Verse'));
+    assert(csvString.startsWith('Book,Chapter,Verse'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 
@@ -128,7 +128,7 @@ describe('API tests', () => {
     const jsonParser = new grammar.JSONParser(jsonObject);
     const csvString = jsonParser.toCSV();
     assert(typeof csvString === 'string');
-    assert(csvString.startsWith('Book, Chapter, Verse'));
+    assert(csvString.startsWith('Book,Chapter,Verse'));
     assert.strictEqual(csvString.split('\n').length, 12);
   });
 

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -210,7 +210,7 @@ describe('Test CLI: USFM parsing', () => {
       'usfm-grammar',
       ['./test/resources/small.usfm', '--output=csv'],
     );
-    const csvPattern = new RegExp('Book, Chapter, Verse, Text\\n.*', 'g');
+    const csvPattern = new RegExp('Book,Chapter,Verse,Text\\n.*', 'g');
     assert.match(response, csvPattern);
   });
 
@@ -219,7 +219,7 @@ describe('Test CLI: USFM parsing', () => {
       'usfm-grammar',
       ['./test/resources/small.usfm', '-o', 'csv'],
     );
-    const csvPattern = new RegExp('Book, Chapter, Verse, Text\\n.*', 'g');
+    const csvPattern = new RegExp('Book,Chapter,Verse,Text\\n.*', 'g');
     assert.match(response, csvPattern);
   });
 });

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -210,7 +210,7 @@ describe('Test CLI: USFM parsing', () => {
       'usfm-grammar',
       ['./test/resources/small.usfm', '--output=csv'],
     );
-    const csvPattern = new RegExp('Book,Chapter,Verse,Text\\n.*', 'g');
+    const csvPattern = new RegExp('"Book","Chapter","Verse"\\n.*', 'g');
     assert.match(response, csvPattern);
   });
 
@@ -219,7 +219,7 @@ describe('Test CLI: USFM parsing', () => {
       'usfm-grammar',
       ['./test/resources/small.usfm', '-o', 'csv'],
     );
-    const csvPattern = new RegExp('Book,Chapter,Verse,Text\\n.*', 'g');
+    const csvPattern = new RegExp('"Book","Chapter","Verse"\\n.*', 'g');
     assert.match(response, csvPattern);
   });
 });


### PR DESCRIPTION
Fix mistakes in outputs
- change wrongly spelt "delimter" to "delimiter"
- Remove space from CSV header