### PR TITLE
Python module: Revised JSON structure and filters

### DIFF
--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -1,0 +1,35 @@
+name: check-linting
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains the linting for python module
+  python-build-n-lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+            python-version: '3.10.6' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+            architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+      - name: Create Virtual Environment
+        run: python -m venv ENV-dev
+      
+      - name: Use VENV
+        run: source ENV-dev/bin/activate
+        
+      - name: install packages
+        working-directory: ./python-usfm-parser
+        run: pip install -r dev-requirements.txt
+        
+      - name: Run linter
+        working-directory: ./python-usfm-parser
+        run: pylint --extension-pkg-allow-list=lxml src/usfm-grammar/*.py

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -32,4 +32,4 @@ jobs:
         
       - name: Run linter
         working-directory: ./python-usfm-parser
-        run: pylint --extension-pkg-allow-list=lxml src/usfm-grammar/*.py
+        run: pylint --extension-pkg-allow-list=lxml src/usfm_grammar/*.py

--- a/python-usfm-parser/src/usfm_grammar/__init__.py
+++ b/python-usfm-parser/src/usfm_grammar/__init__.py
@@ -2,6 +2,7 @@
 
 from usfm_grammar import usfm_parser
 
+Filter_new = usfm_parser.Filter_new
 Filter = usfm_parser.Filter
 Format = usfm_parser.Format
 USFMParser = usfm_parser.USFMParser

--- a/python-usfm-parser/src/usfm_grammar/__init__.py
+++ b/python-usfm-parser/src/usfm_grammar/__init__.py
@@ -2,7 +2,6 @@
 
 from usfm_grammar import usfm_parser
 
-Filter_new = usfm_parser.Filter_new
 Filter = usfm_parser.Filter
 Format = usfm_parser.Format
 USFMParser = usfm_parser.USFMParser

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -11,7 +11,8 @@ from usfm_grammar import USFMParser, Filter, Format
 class Filter_CLI(str, Enum):
     '''Defines the values of filter options'''
     BOOK_HEADERS = "BOOK_HEADERS"
-    PARAS_N_TITLES = 'PARAS_N_TITLES'
+    PARAGRAPHS = 'PARAGRAPHS'
+    TITLES = 'TITLES'
     SCRIPTURE_TEXT = 'SCRIPTURE_TEXT'
     NOTES = "NOTES"
     ATTRIBUTES = "ATTRIBUTES"
@@ -65,8 +66,10 @@ def main():
             updated_filt.append(Filter.NOTES)
         if Filter_CLI.ATTRIBUTES in output_filter:
             updated_filt.append(Filter.ATTRIBUTES)
-        if Filter_CLI.PARAS_N_TITLES in output_filter:
-            updated_filt.append(Filter.PARAS_N_TITLES)
+        if Filter_CLI.PARAGRAPHS in output_filter:
+            updated_filt.append(Filter.PARAGRAPHS)
+        if Filter_CLI.TITLES in output_filter:
+            updated_filt.append(Filter.TITLES)
         if Filter_CLI.MILESTONES in output_filter:
             updated_filt.append(Filter.MILESTONES)
         if Filter_CLI.STUDY_BIBLE in output_filter:

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import sys
-from enum import Enum
 from lxml import etree
 
 from usfm_grammar import USFMParser, Filter, Format

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -8,7 +8,7 @@ from lxml import etree
 
 from usfm_grammar import USFMParser, Filter, Format
 
-class Filter_CLI(str, Enum):
+class FilterCLI(str, Enum):
     '''Defines the values of filter options'''
     BOOK_HEADERS = "BOOK_HEADERS"
     PARAGRAPHS = 'PARAGRAPHS'
@@ -29,7 +29,7 @@ def main():
                             choices=[itm.value for itm in Format],
                             default=Format.JSON.value)
     arg_parser.add_argument('--filter', type=str, help='the type of contents to be included',
-                            choices=[itm.value for itm in Filter_CLI],
+                            choices=[itm.value for itm in FilterCLI],
                             action="append")
     arg_parser.add_argument('--csv_col_sep', type=str,
                             help="column separator or delimiter. Only useful with format=table.",
@@ -58,21 +58,21 @@ def main():
         updated_filt = None
     else:
         updated_filt = []
-        if Filter_CLI.BOOK_HEADERS in output_filter:
+        if FilterCLI.BOOK_HEADERS in output_filter:
             updated_filt.append(Filter.BOOK_HEADERS)
-        if Filter_CLI.SCRIPTURE_TEXT in output_filter:
+        if FilterCLI.SCRIPTURE_TEXT in output_filter:
             updated_filt.append(Filter.SCRIPTURE_TEXT)
-        if Filter_CLI.NOTES in output_filter:
+        if FilterCLI.NOTES in output_filter:
             updated_filt.append(Filter.NOTES)
-        if Filter_CLI.ATTRIBUTES in output_filter:
+        if FilterCLI.ATTRIBUTES in output_filter:
             updated_filt.append(Filter.ATTRIBUTES)
-        if Filter_CLI.PARAGRAPHS in output_filter:
+        if FilterCLI.PARAGRAPHS in output_filter:
             updated_filt.append(Filter.PARAGRAPHS)
-        if Filter_CLI.TITLES in output_filter:
+        if FilterCLI.TITLES in output_filter:
             updated_filt.append(Filter.TITLES)
-        if Filter_CLI.MILESTONES in output_filter:
+        if FilterCLI.MILESTONES in output_filter:
             updated_filt.append(Filter.MILESTONES)
-        if Filter_CLI.STUDY_BIBLE in output_filter:
+        if FilterCLI.STUDY_BIBLE in output_filter:
             updated_filt.append(Filter.STUDY_BIBLE)
 
     match output_format:
@@ -83,11 +83,11 @@ def main():
             table_output = my_parser.to_list(filt = updated_filt)
             print(csv_row_sep.join([csv_col_sep.join(row) for row in table_output]))
         case Format.USX:
-            xmlstr = etree.tostring(my_parser.to_usx(filt=updated_filt),
+            xmlstr = etree.tostring(my_parser.to_usx(),
                 encoding='unicode', pretty_print=True)
             print(xmlstr)
         case Format.MD:
-            print(my_parser.to_markdown(filt = updated_filt))
+            print(my_parser.to_markdown())
         case Format.ST:
             print(my_parser.to_syntax_tree())
         case _:

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -5,7 +5,7 @@ import json
 import sys
 from lxml import etree
 
-from usfm_grammar import USFMParser, Filter, Format
+from usfm_grammar import USFMParser, Filter, Format, Filter_new
 
 def main():
     '''handles the command line requests'''
@@ -45,7 +45,7 @@ def main():
 
     match output_format:
         case Format.JSON:
-            dict_output = my_parser.to_dict(filt = output_filter)
+            dict_output = my_parser.to_dict_new()
             print(json.dumps(dict_output, indent=4, ensure_ascii=False))
         case Format.CSV:
             table_output = my_parser.to_list(filt = output_filter)

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -8,17 +8,6 @@ from lxml import etree
 
 from usfm_grammar import USFMParser, Filter, Format
 
-class FilterCLI(str, Enum):
-    '''Defines the values of filter options'''
-    BOOK_HEADERS = "BOOK_HEADERS"
-    PARAGRAPHS = 'PARAGRAPHS'
-    TITLES = 'TITLES'
-    SCRIPTURE_TEXT = 'SCRIPTURE_TEXT'
-    NOTES = "NOTES"
-    ATTRIBUTES = "ATTRIBUTES"
-    MILESTONES = "MILESTONES"
-    STUDY_BIBLE = "STUDY_BIBLE"
-
 def main():
     '''handles the command line requests'''
     arg_parser = argparse.ArgumentParser(
@@ -29,7 +18,7 @@ def main():
                             choices=[itm.value for itm in Format],
                             default=Format.JSON.value)
     arg_parser.add_argument('--filter', type=str, help='the type of contents to be included',
-                            choices=[itm.value for itm in FilterCLI],
+                            choices=[itm.name.lower() for itm in Filter],
                             action="append")
     arg_parser.add_argument('--csv_col_sep', type=str,
                             help="column separator or delimiter. Only useful with format=table.",
@@ -58,22 +47,8 @@ def main():
         updated_filt = None
     else:
         updated_filt = []
-        if FilterCLI.BOOK_HEADERS in output_filter:
-            updated_filt.append(Filter.BOOK_HEADERS)
-        if FilterCLI.SCRIPTURE_TEXT in output_filter:
-            updated_filt.append(Filter.SCRIPTURE_TEXT)
-        if FilterCLI.NOTES in output_filter:
-            updated_filt.append(Filter.NOTES)
-        if FilterCLI.ATTRIBUTES in output_filter:
-            updated_filt.append(Filter.ATTRIBUTES)
-        if FilterCLI.PARAGRAPHS in output_filter:
-            updated_filt.append(Filter.PARAGRAPHS)
-        if FilterCLI.TITLES in output_filter:
-            updated_filt.append(Filter.TITLES)
-        if FilterCLI.MILESTONES in output_filter:
-            updated_filt.append(Filter.MILESTONES)
-        if FilterCLI.STUDY_BIBLE in output_filter:
-            updated_filt.append(Filter.STUDY_BIBLE)
+        for itm in output_filter:
+            updated_filt.append(Filter[itm.upper()])
 
     match output_format:
         case Format.JSON:

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -38,7 +38,7 @@ USFM_LANGUAGE = Language(str(lang_file), 'usfm3')
 parser = Parser()
 parser.set_language(USFM_LANGUAGE)
 
-PARA_STYLE_MARKERS = ["h", "toc", "toca" #identification
+PARA_STYLE_MARKERS = ["ide", "usfm", "h", "toc", "toca" #identification
                     "imt", "is", "ip", "ipi", "im", "imi", "ipq", "imq", "ipr", "iq", "ib",
                     "ili", "iot", "io", "iex", "imte", "ie", # intro
                     "mt", "mte", "cl", "cd", "ms", "mr", "s", "sr", "r", "d", "sp", "sd", #titles
@@ -369,7 +369,7 @@ def node_2_dict_generic(node, usfm_bytes, filt):
             tag_node.start_byte:tag_node.end_byte].decode('utf-8').strip().replace("\\","")
     if len(content) == 1:
         content = content[0]
-    if text_node is not None: # Assumption: when text content is present inner contents will not be there!
+    if text_node is not None: # when text content is present inner contents will not be there!
         content = usfm_bytes[text_node.start_byte:text_node.end_byte].decode('utf-8').strip() 
     result = {marker_name:content}
     if len(attribs) > 0:
@@ -431,6 +431,19 @@ def node_2_dict_new(node, usfm_bytes, filt):
         for child in node.children:
             result.append(node_2_dict_new(child, usfm_bytes, filt))
         return result
+    if node.type in ['footnote', 'crossref']:
+        return node_2_dict_new(node.children[0], usfm_bytes, filt)
+    if node.type == 'caller':
+        return {"caller": usfm_bytes[node.start_byte:node.end_byte].decode('utf-8').strip()}
+    if node.type == "noteText":
+        result = []
+        for child in node.children:
+            result.append(node_2_dict_new(child, usfm_bytes, filt))
+        return result
+    if node.type == 'text':
+        val = usfm_bytes[node.start_byte:node.end_byte].decode('utf-8').strip()
+        if val != "":
+            return val
     return None
 
 ###########^^^^^^^^^^^ Logics for syntax-tree to dict conversions ^^^^^^^^^ ##############

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -22,6 +22,8 @@ class Filter_new(str, Enum):
     SCRIPTURE_TEXT = 'verse-texts'
     NOTES = "footnotes-and-crossrefs"
     WORD_EMBEDDINGS = "character-level-markers"
+    MILESTONES = "milestones-namespaces"
+    STUDY_BIBLE = "sidebars-extended-contents"
 
 class Format(str, Enum):
     '''Defines the valid values for output formats'''
@@ -438,7 +440,7 @@ def get_captured_node(all_captures, key):
 
 ######## Newly formed queries#############
 
-id_query = USFM_LANGUAGE.query('''(File (book (id (bookcode) @book-code (description) @desc)))''')
+id_query = USFM_LANGUAGE.query('''(book (id (bookcode) @book-code (description) @desc))''')
 
 chapter_data_query = USFM_LANGUAGE.query('''(c (chapterNumber) @chapter-number)
                                             (cl (text) @cl-text)
@@ -524,8 +526,10 @@ class USFMParser():
                                     dict_output['book']['bookCode'] = self.usfm_bytes[\
                                         node.start_byte:node.end_byte].decode('utf-8').strip()
                                 case (node, "desc"):
-                                    dict_output['book']['fileDescription'] = self.usfm_bytes[\
+                                    val = self.usfm_bytes[\
                                         node.start_byte:node.end_byte].decode('utf-8').strip()
+                                    if val != "":
+                                        dict_output['book']['fileDescription'] = val
                     case "chapter":
                         if "chapters" not in dict_output['book']:
                             dict_output['book']['chapters'] = [] 

--- a/tree-sitter-usfm3/grammar.js
+++ b/tree-sitter-usfm3/grammar.js
@@ -52,8 +52,10 @@ module.exports = grammar({
 
     h: $ => seq($.hTag, $.text),
     hTag: $ => seq("\\h",optional($.numberedLevelMax3), " "),
-    toc: $ => seq("\\toc",optional($.numberedLevelMax3), " ", $.text),
-    toca: $ => seq("\\toca",optional($.numberedLevelMax3), " ", $.text),
+    toc: $ => seq($.tocTag, $.text),
+    tocTag: $ => seq("\\toc",optional($.numberedLevelMax3), " "),
+    toca: $ => seq($.tocaTag, $.text),
+    tocaTag: $ => seq("\\toca",optional($.numberedLevelMax3), " "),
 
     // Remarks and Comments
     _comments: $ => choice($.rem, $.sts, $.restore, $.lit),

--- a/tree-sitter-usfm3/test/corpus/test1_headers.txt
+++ b/tree-sitter-usfm3/test/corpus/test1_headers.txt
@@ -135,13 +135,16 @@ toc markers under h
       (text))
     (tocBlock
       (toc
-        (numberedLevelMax3)
+        (tocTag
+          (numberedLevelMax3))
         (text))
       (toc
-        (numberedLevelMax3)
+        (tocTag
+          (numberedLevelMax3))
         (text))
       (toc
-        (numberedLevelMax3)
+        (tocTag
+          (numberedLevelMax3))
         (text)))))
 
 ================================================================================
@@ -165,13 +168,16 @@ toc markers without h
   (usfm)
   (tocBlock
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))))
 
 ================================================================================
@@ -200,12 +206,15 @@ toca markers
       (text))
     (tocaBlock
       (toca
+        (tocaTag)
         (text))
       (toca
-        (numberedLevelMax3)
+        (tocaTag
+          (numberedLevelMax3))
         (text))
       (toca
-        (numberedLevelMax3)
+        (tocaTag
+          (numberedLevelMax3))
         (text)))))
 
 ================================================================================
@@ -237,19 +246,25 @@ toca markers along with toc
       (text))
     (tocBlock
       (toc
+        (tocTag)
         (text))
       (toc
-        (numberedLevelMax3)
+        (tocTag
+          (numberedLevelMax3))
         (text))
       (toc
-        (numberedLevelMax3)
+        (tocTag
+          (numberedLevelMax3))
         (text)))
     (tocaBlock
       (toca
+        (tocaTag)
         (text))
       (toca
-        (numberedLevelMax3)
+        (tocaTag
+          (numberedLevelMax3))
         (text))
       (toca
-        (numberedLevelMax3)
+        (tocaTag
+          (numberedLevelMax3))
         (text)))))

--- a/tree-sitter-usfm3/test/corpus/test2_comments.txt
+++ b/tree-sitter-usfm3/test/corpus/test2_comments.txt
@@ -67,13 +67,16 @@ rem between toc markers and h
     (text))
   (tocBlock
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))))
 
 ================================================================================
@@ -145,13 +148,16 @@ sts between toc markers and h
     (text))
   (tocBlock
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))))
 
 ================================================================================

--- a/tree-sitter-usfm3/test/corpus/test5_titles_n_paragraphs.txt
+++ b/tree-sitter-usfm3/test/corpus/test5_titles_n_paragraphs.txt
@@ -35,10 +35,12 @@ headers and titles
   (usfm)
   (tocBlock
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text)))
   (mtBlock
     (mt
@@ -139,10 +141,12 @@ Simple p
   (usfm)
   (tocBlock
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text))
     (toc
-      (numberedLevelMax3)
+      (tocTag
+        (numberedLevelMax3))
       (text)))
   (ip
     (text))


### PR DESCRIPTION
The python module, especially the `to_dict()` or `--format json` API, has been re-written completely with the following effects

* The JSON output has been changed
 <table>
  <tr>
    <th>USFM</th>
    <th>New JSON(with all contents)</th>
    <th>Old JSON(with filter=all)</th>
  </tr>
  <tr>
    <td>
<pre><code>
\id GEN
\h Genesis
\c 1
\p
\v 1 test verse
</code></pre>
</td>
<td><pre><code>
{"book": {
  "bookCode": "GEN",
  "headers": [
      {"h": "Genesis"}
   ],
   "chapters": [
      {"chapterNumber": "1",
         "contents": [
            {"p": [{"verseNumber": "1"},
                   {"verseText": "test verse"}]
            }]
      }]
}}
</code></pre></td>
<td>
<pre><code>
[{"book": [
    {"id": ["\\id ",
            {"bookcode": ["GEN"]},
            {"description": "\n"}]}]
 },
 {"hBlock": [{"h": [
                    {"hTag": ["\\h"," "]},
                    {"text": "Genesis\n"}]}]
 },
 {"chapter": [
            {"c": ["\\c ",{"chapterNumber": "1"}]},
            {"paragraph": [{"p": [
                            "\\p",
                            {"v": ["\\v ",{"verseNumber": "1 "}]},
                            {"verseText": [{"text": "test verse\n"}]}
                        ]}]
            }]
 }
]
</code></pre>
</td>


  </tr>
</table> 

* Filter options changed 
`[--filter {scripture-bcv,notes,scripture-paragraph,all}]`
to 
`[--filter {BOOK_HEADERS,PARAGRAPHS,TITLES,SCRIPTURE_TEXT,NOTES,ATTRIBUTES,MILESTONES,STUDY_BIBLE}]`


Also, the way filter is used has been changed. Instead of selecting one option, now user can add more than one filter choice and include different combinations of the contents he needs to extract from the USFM. Example, scripture-and-notes, notes-and-milestones, scripture-and-titles, scripture-paragraphs-and-titles etc.

* The `to_list()` or `--format table` API, used for getting TSV outputs, has been re-written to work according to the JSON changes. This API is internally dependant on the `to_dict()` api and just re-formats the dict output to a convenient list form. But this api cannot handle the paragraph filter option, as the nested structure of paragraphs is hard to implement in a table output format.

*  Added linting check on gitactions for the python module

* As part of the above to_dict refactoring, one grammar rule had to be changed(`toc`) to follow the pattern of other marker rules. This results in a slight change in the syntax tree. 