### PR TITLE
Remove quotes in List output

### DIFF
--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import sys
+import csv
 from lxml import etree
 
 from usfm_grammar import USFMParser, Filter, Format
@@ -55,7 +56,9 @@ def main():
             print(json.dumps(dict_output, indent=4, ensure_ascii=False))
         case Format.CSV:
             table_output = my_parser.to_list(filt = updated_filt)
-            print(csv_row_sep.join([csv_col_sep.join(row) for row in table_output]))
+            outfile = sys.stdout
+            writer = csv.writer(outfile, delimiter=csv_col_sep, lineterminator=csv_row_sep)
+            writer.writerows(table_output)
         case Format.USX:
             xmlstr = etree.tostring(my_parser.to_usx(),
                 encoding='unicode', pretty_print=True)

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -757,8 +757,8 @@ class USFMParser():
                 if first_key == "verseNumber":
                     if verse_num != 0:
                         row = [book, chapter, verse_num,
-                                '"'+verse_text+'"','"'+note_text+'"',
-                                '"'+ms_text+'"','"'+title_text+'"']
+                                verse_text,note_text,
+                                ms_text,title_text]
                         table_output.append(row)
                     verse_text = ""
                     note_text = ""

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -777,8 +777,8 @@ class USFMParser():
                     print(first_key)
                     title_text += str(item[first_key])
             row = [book, chapter, verse_num,
-                    '"'+verse_text+'"','"'+note_text+'"',
-                    '"'+ms_text+'"','"'+title_text+'"']
+                    verse_text,note_text,
+                    ms_text,title_text]
             table_output.append(row)
         return table_output
 


### PR DESCRIPTION
Fixes #188 
The `to_list()` API called within python was returning quoted strings.
```
[['Book', 'Chapter', 'Verse', 'Verse-Text', 'Notes', 'Milestone', 'Other'], 
['GEN', '1', '1', '"test with "quote" "', '""', '""', '""'], 
['GEN', '1', '2', '"and no quote "', '""', '""', '""']]
```
After the update
```
[['Book', 'Chapter', 'Verse', 'Verse-Text', 'Notes', 'Milestone', 'Other'], 
['GEN', '1', '1', 'test with "quote" ', '', '', ''], 
['GEN', '1', '2', 'and no quote ', '', '', '']]
```
Now using CSV writer in CLI to add quotes if required
```
Book	Chapter	Verse	Verse-Text	Notes	Milestone	Other
GEN	1	1	"test with ""quote"" "			
GEN	1	2	and no quote
```