### PR TITLE
Minor changes in Python module

### DIFF
--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Run tests for parsing errors
         working-directory: ./python-usfm-parser
         run:
-          pytest -k "not compare_usx_with_testsuite_samples and not testsuite_usx_with_rnc_grammar and not samples-from-wild"
+          pytest -k "not compare_usx_with_testsuite_samples and not testsuite_usx_with_rnc_grammar and not samples-from-wild" -n auto

--- a/python-usfm-parser/dev-requirements.txt
+++ b/python-usfm-parser/dev-requirements.txt
@@ -5,4 +5,5 @@ lxml==4.9.1
 pylint==2.15.3
 pytest==7.1.3
 pytest-timeout==2.1.0
+pytest-xdist==3.1.0
 bump2version==1.0.1

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -50,10 +50,10 @@ def main():
 
     match output_format:
         case Format.JSON:
-            dict_output = my_parser.to_dict(filt=updated_filt)
+            dict_output = my_parser.to_dict(filters=updated_filt)
             print(json.dumps(dict_output, indent=4, ensure_ascii=False))
         case Format.CSV:
-            table_output = my_parser.to_list(filt = updated_filt)
+            table_output = my_parser.to_list(filters = updated_filt)
             outfile = sys.stdout
             writer = csv.writer(outfile,
                 delimiter=arg_parser.parse_args().csv_col_sep,

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -396,7 +396,7 @@ def node_2_dict_chapter(chapter_node, usfm_bytes):
     for chap_data in chapter_data_cap:
         match chap_data:
             case (node, "chapter-number"):
-                chapter_output['chapterNumber'] = usfm_bytes[\
+                chapter_output['c'] = usfm_bytes[\
                     node.start_byte:node.end_byte].decode('utf-8').strip()
             case (node, "cl-text"):
                 chapter_output['cl'] = usfm_bytes[node.start_byte:
@@ -417,7 +417,7 @@ def node_2_dict_verse(verse_node, usfm_bytes):
     for v_cap in verse_caps:
         match v_cap:
             case (in_node, "verse-number"):
-                result['verseNumber'] = usfm_bytes[\
+                result['v'] = usfm_bytes[\
                     in_node.start_byte:in_node.end_byte].decode('utf-8').strip()
             case (in_node, "va-number"):
                 result['va'] = usfm_bytes[\

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -52,7 +52,8 @@ CHAR_STYLE_MARKERS = [ "add", "bk", "dc", "ior", "iqt", "k", "litl", "nd", "ord"
                      "xo", "xop", "xt", "xta", "xk", "xq", "xot", "xnt", "xdc" #crossref-content
                      ]
 NESTED_CHAR_STYLE_MARKERS = [item+"Nested" for item in CHAR_STYLE_MARKERS]
-DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt"}
+DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt",
+                    "xt_standalone":"link-href"}
 TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
 
 ANY_VALID_MARKER = PARA_STYLE_MARKERS+NOTE_MARKERS+CHAR_STYLE_MARKERS+\

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -733,8 +733,9 @@ class USFMParser():
                             dict_output['book']['headers'].append(
                                 node_2_dict(child, self.usfm_bytes, filters))
         except Exception as exe:
+            err_str = "\n\t".join([":".join(err) for err in self.errors])
             raise Exception("Unable to do the conversion. "+\
-                "Check for errors in <USFMParser obj>.errors") from exe
+                f"Could be due to an error in the USFM\n\t{err_str}")  from exe
         return dict_output
 
     def to_list(self, filters=None):
@@ -794,6 +795,7 @@ class USFMParser():
         try:
             node_2_usx(self.syntax_tree, self.usfm_bytes, usx_root, usx_root)
         except Exception as exe:
+            err_str = "\n\t".join([":".join(err) for err in self.errors])
             raise Exception("Unable to do the conversion. "+\
-                "Check for errors in <USFMParser obj>.errors") from exe
+                f"Could be due to an error in the USFM\n\t{err_str}")  from exe
         return usx_root

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -360,8 +360,8 @@ def node_2_usx(node, usfm_bytes, parent_xml_node, xml_root_node): # pylint: disa
     elif len(node.children)>0:
         for child in node.children:
             node_2_usx(child, usfm_bytes, parent_xml_node, xml_root_node)
-    else:
-        raise Exception("Encountered unknown element ", str(node))
+    # else:
+    #     raise Exception("Encountered unknown element ", str(node))
 
 ###########VVVVVVVVV Logics for syntax-tree to dict conversions VVVVVV ##############
 def reduce_nesting(func):

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -790,6 +790,9 @@ class USFMParser():
         '''convert the syntax_tree to the XML format USX'''
         usx_root = etree.Element("usx")
         usx_root.set("version", "3.0")
-
-        node_2_usx(self.syntax_tree, self.usfm_bytes, usx_root, usx_root)
+        try:
+            node_2_usx(self.syntax_tree, self.usfm_bytes, usx_root, usx_root)
+        except Exception as exe:
+            raise Exception("Unable to do the conversion. "+\
+                "Check for errors in <USFMParser obj>.errors") from exe
         return usx_root

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -774,7 +774,6 @@ class USFMParser():
                 elif first_key in NOTE_MARKERS:
                     note_text += str(item)
                 else:
-                    print(first_key)
                     title_text += str(item[first_key])
             row = [book, chapter, verse_num,
                     verse_text,note_text,


### PR DESCRIPTION
This PR includes
* The argument `filt` is changed to `filters`. Using plural because `filter` is a python reserved keyword and also our variable is a list.
* Removed `print()` from code that was added during development
* In the JSON output, changed keys (#193 )
   * `chapterNumber` to `c`
   * `verseNumber` to `v`
*  Handle failures in `to_usx()` (#183 )
   * Not raise error when unknown nodes are seen, allowing some valid USX output even when there are errors in parsing
   * Give better error report in case of failure
* Handle default attribute usage in `\xt` (#184 )
* Use multiple CPUs to run pytest, allowing much increase in performance. details [here](https://github.com/Bridgeconn/vachan-api/issues/468#issuecomment-1346014258) . This requires an additional plugin though