### PR TITLE
Fix issue of missing components in output

### DIFF
--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -490,9 +490,7 @@ def node_2_dict_generic(node, usfm_bytes, filters):
             tag_node = child
             marker_name = usfm_bytes[\
                 tag_node.start_byte:tag_node.end_byte].decode('utf-8').strip().replace("\\","")
-        elif child.type == "text":
-            text_node = child
-        elif child.type == "category":
+        elif child.type in ["text", "category"]:
             text_node = child
         elif child.type.strip().startswith('\\') and child.type.strip().endswith("*"):
             closing_node = child

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -755,9 +755,11 @@ class USFMParser():
                             dict_output['book']['headers'].append(
                                 node_2_dict(child, self.usfm_bytes, filters))
         except Exception as exe:
-            err_str = "\n\t".join([":".join(err) for err in self.errors])
-            raise Exception("Unable to do the conversion. "+\
-                f"Could be due to an error in the USFM\n\t{err_str}")  from exe
+            message = "Unable to do the conversion. "
+            if self.errors:
+                err_str = "\n\t".join([":".join(err) for err in self.errors])
+                message += f"Could be due to an error in the USFM\n\t{err_str}"
+            raise Exception(message)  from exe
         return dict_output
 
     def to_list(self, filters=None):
@@ -817,7 +819,9 @@ class USFMParser():
         try:
             node_2_usx(self.syntax_tree, self.usfm_bytes, usx_root, usx_root)
         except Exception as exe:
-            err_str = "\n\t".join([":".join(err) for err in self.errors])
-            raise Exception("Unable to do the conversion. "+\
-                f"Could be due to an error in the USFM\n\t{err_str}")  from exe
+            message = "Unable to do the conversion. "
+            if self.errors:
+                err_str = "\n\t".join([":".join(err) for err in self.errors])
+                message += f"Could be due to an error in the USFM\n\t{err_str}"
+            raise Exception(message)  from exe
         return usx_root

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -181,7 +181,7 @@ def node_2_usx_para(node, usfm_bytes, parent_xml_node, xml_root_node):
         para_marker = usfm_bytes[node.children[0].start_byte:\
             node.children[0].end_byte].decode('utf-8').replace("\\", "").strip()
         para_xml_node = etree.SubElement(parent_xml_node, "para")
-        parent_xml_node.set("style", para_marker)
+        para_xml_node.set("style", para_marker)
         for child in node.children[1:]:
             node_2_usx(child, usfm_bytes, para_xml_node, xml_root_node)
 

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -560,7 +560,7 @@ def node_2_dict(node, usfm_bytes, filters): # pylint: disable=too-many-return-st
         return result
     if node.type == "poetry":
         result = {"poetry":[]}
-        for child in node.children[0].children:
+        for child in node.children:
             processed = node_2_dict(child,usfm_bytes, filters)
             if processed is not None:
                 result['poetry'].append(processed)

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -57,7 +57,8 @@ DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt",
 TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
 
 ANY_VALID_MARKER = PARA_STYLE_MARKERS+NOTE_MARKERS+CHAR_STYLE_MARKERS+\
-                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+["fig", "cat", "esb", "b"]
+                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+\
+                    ["fig", "cat", "esb", "b", "ph", "pi"]
 
 def node_2_usx_id(node, usfm_bytes,parent_xml_node):
     '''build id node in USX'''
@@ -546,6 +547,9 @@ def node_2_dict(node, usfm_bytes, filters): # pylint: disable=too-many-return-st
                 result.append(processed)
         return result
     if node.type == "paragraph":
+        if node.children[0].type.endswith("Block"):
+            processed = node_2_dict(node.children[0], usfm_bytes, filters)
+            return processed
         result = {node.children[0].type: []}
         for child in node.children[0].children[1:]:
             processed = node_2_dict(child,usfm_bytes, filters)

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -584,7 +584,12 @@ def node_2_dict(node, usfm_bytes, filters): # pylint: disable=too-many-return-st
         if Filter.PARAGRAPHS not in filters:
             new_result = []
             for block in result['list']:
-                val = list(block.values())
+                if isinstance(block, dict):
+                    val = list(block.values())
+                elif isinstance(block, list):
+                    val = []
+                    for item in block:
+                        val += list(item.values())
                 if val and val != [[]]:
                     new_result += val
             return new_result
@@ -796,7 +801,7 @@ class USFMParser():
                 elif first_key == "milestone":
                     ms_text += str(item) + "\n"
                 elif first_key in CHAR_STYLE_MARKERS:
-                    verse_text += item[first_key] + " "
+                    verse_text += str(item[first_key]) + " "
                 elif first_key in NOTE_MARKERS:
                     note_text += str(item)
                 else:

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -57,7 +57,7 @@ DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt",
 TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
 
 ANY_VALID_MARKER = PARA_STYLE_MARKERS+NOTE_MARKERS+CHAR_STYLE_MARKERS+\
-                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+["fig", "cat", "esb"]
+                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+["fig", "cat", "esb", "b"]
 
 def node_2_usx_id(node, usfm_bytes,parent_xml_node):
     '''build id node in USX'''
@@ -477,7 +477,7 @@ def node_2_dict_milestone(ms_node, usfm_bytes):
         result['attributes'] = attribs
     return result
 
-def node_2_dict_generic(node, usfm_bytes, filters):
+def node_2_dict_generic(node, usfm_bytes, filters): # pylint: disable=R0912
     '''The general rules to cover the common marker types'''
     marker_name = node.type
     content = []
@@ -508,6 +508,8 @@ def node_2_dict_generic(node, usfm_bytes, filters):
                 text_node.start_byte:text_node.end_byte].decode('utf-8').strip())
     if len(content) == 1:
         content = content[0]
+    elif len(content) == 0:
+        content = None
     result = {marker_name:content}
     if len(attribs) > 0:
         result['attributes'] = attribs

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -166,7 +166,10 @@ def node_2_usx_verse(node, usfm_bytes, parent_xml_node, xml_root_node):
 
 def node_2_usx_para(node, usfm_bytes, parent_xml_node, xml_root_node):
     '''build paragraph nodes in USX'''
-    if node.type == 'paragraph' and not node.children[0].type.endswith('Block'):
+    if node.children[0].type.endswith('Block'):
+        for child in node.children[0].children:
+            node_2_usx_para(child, usfm_bytes, parent_xml_node, xml_root_node)
+    elif node.type == 'paragraph':
         para_tag_cap = USFM_LANGUAGE.query("(paragraph (_) @para-marker)").captures(node)[0]
         para_marker = para_tag_cap[0].type
         if not para_marker.endswith("Block"):

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -518,8 +518,9 @@ def node_2_dict(node, usfm_bytes, filters): # pylint: disable=too-many-return-st
             result = []
             for child in node.children:
                 if child.type == "text":
-                    result.append({'verseText':usfm_bytes[\
-                            child.start_byte:child.end_byte].decode('utf-8').strip()})
+                    text = usfm_bytes[child.start_byte:child.end_byte].decode('utf-8').strip()
+                    if text != "":
+                        result.append({'verseText':text})
                 else:
                     processed = node_2_dict(child,usfm_bytes, filters)
                     if processed is not None:

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -57,7 +57,7 @@ DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt",
 TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
 
 ANY_VALID_MARKER = PARA_STYLE_MARKERS+NOTE_MARKERS+CHAR_STYLE_MARKERS+\
-                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+["fig"]
+                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+["fig", "cat", "esb"]
 
 def node_2_usx_id(node, usfm_bytes,parent_xml_node):
     '''build id node in USX'''
@@ -481,6 +481,8 @@ def node_2_dict_generic(node, usfm_bytes, filters):
             marker_name = usfm_bytes[\
                 tag_node.start_byte:tag_node.end_byte].decode('utf-8').strip().replace("\\","")
         elif child.type == "text":
+            text_node = child
+        elif child.type == "category":
             text_node = child
         elif child.type.strip().startswith('\\') and child.type.strip().endswith("*"):
             closing_node = child

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -775,10 +775,10 @@ class USFMParser():
         ms_text = ""
         title_text = ''
         for chap in scripture_json['book']['chapters']:
-            chapter = chap['chapterNumber']
+            chapter = chap['c']
             for item in chap['contents']:
                 first_key = list(item.keys())[0]
-                if first_key == "verseNumber":
+                if first_key == "v":
                     if verse_num != 0:
                         row = [book, chapter, verse_num,
                                 verse_text,note_text,
@@ -788,7 +788,7 @@ class USFMParser():
                     note_text = ""
                     ms_text = ""
                     title_text = ''
-                    verse_num = item['verseNumber']
+                    verse_num = item['v']
                 elif first_key == 'verseText':
                     verse_text += item['verseText'] +" "
                 elif first_key == "milestone":

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -57,7 +57,7 @@ DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt",
 TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
 
 ANY_VALID_MARKER = PARA_STYLE_MARKERS+NOTE_MARKERS+CHAR_STYLE_MARKERS+\
-                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS
+                    NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+["fig"]
 
 def node_2_usx_id(node, usfm_bytes,parent_xml_node):
     '''build id node in USX'''
@@ -558,7 +558,7 @@ def node_2_dict(node, usfm_bytes, filters): # pylint: disable=too-many-return-st
     if node.type == "list":
         result = {'list':[]}
         for child in node.children:
-            processed = node_2_dict(child,usfm_bytes, filt)
+            processed = node_2_dict(child,usfm_bytes, filters)
             if processed is not None:
                 result['list'].append(processed)
         if Filter.PARAGRAPHS not in filters:

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -32,6 +32,7 @@ USFM_LANGUAGE = Language(str(lang_file), 'usfm3')
 parser = Parser()
 parser.set_language(USFM_LANGUAGE)
 
+# handled alike by the node_2_usx_generic method
 PARA_STYLE_MARKERS = ["ide", "usfm", "h", "toc", "toca", #identification
                     "imt", "is", "ip", "ipi", "im", "imi", "ipq", "imq", "ipr", "iq", "ib",
                     "ili", "iot", "io", "iex", "imte", "ie", # intro
@@ -55,10 +56,12 @@ NESTED_CHAR_STYLE_MARKERS = [item+"Nested" for item in CHAR_STYLE_MARKERS]
 DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"link-href", "fig":"alt",
                     "xt_standalone":"link-href"}
 TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
+MISC_MARKERS = ["fig", "cat", "esb", "b", "ph", "pi"]
 
+# Handled alike by the node_2_dict_generic method
 ANY_VALID_MARKER = PARA_STYLE_MARKERS+NOTE_MARKERS+CHAR_STYLE_MARKERS+\
                     NESTED_CHAR_STYLE_MARKERS+TABLE_CELL_MARKERS+\
-                    ["fig", "cat", "esb", "b", "ph", "pi"]
+                    MISC_MARKERS
 
 def node_2_usx_id(node, usfm_bytes,parent_xml_node):
     '''build id node in USX'''

--- a/python-usfm-parser/tests/__init__.py
+++ b/python-usfm-parser/tests/__init__.py
@@ -1,5 +1,6 @@
 '''The common methods and objects needed in all tests. To be run before all tests'''
 from glob import glob
+import re
 from lxml import etree
 from src.usfm_grammar import USFMParser
 
@@ -26,6 +27,23 @@ def is_valid_usfm(input_usfm_path):
     if node.text == "fail":
         return False
     return True
+
+def find_all_markers(usfm_path, keep_id=False, keep_number=True):
+    '''To use regex pattern and finall markers in the USFM file'''
+    with open(usfm_path, "r", encoding="utf-8") as in_usfm_file:
+        usfm_str = in_usfm_file.read()
+        all_markers_in_input =re.findall(r"\\(([A-Za-z]+)\d*(-[se])?)", usfm_str)
+    if keep_number:
+        all_markers_in_input = [find[0] for find in all_markers_in_input]
+    else:
+        all_markers_in_input = [find[1] for find in all_markers_in_input]
+    all_markers_in_input = list(set(all_markers_in_input))
+    if not keep_id:
+        all_markers_in_input.remove("id")
+    if "esbe" in all_markers_in_input:
+        assert "esb" in all_markers_in_input
+        all_markers_in_input.remove("esbe")
+    return all_markers_in_input
 
 all_usfm_files = glob(f"{TEST_DIR}/*/*/origin.usfm")
 

--- a/python-usfm-parser/tests/test_json_conversion.py
+++ b/python-usfm-parser/tests/test_json_conversion.py
@@ -49,6 +49,7 @@ def test_all_markers_are_in_output(file_path):
     usfm_dict = test_parser.to_dict()
     all_json_keys = get_keys(usfm_dict)
     for marker in all_markers_in_input:
-        if marker.endswith("-s") or marker.endswith("-e") or marker.startswith("z"):
+        if (marker in ["ts", "qt"] or marker.endswith("-s") or \
+            marker.endswith("-e") or marker.startswith("z")):
             marker = "milestone"
         assert marker in all_json_keys, marker

--- a/python-usfm-parser/tests/test_json_conversion.py
+++ b/python-usfm-parser/tests/test_json_conversion.py
@@ -39,13 +39,16 @@ def test_all_markers_are_in_output(file_path):
 
     with open(file_path, "r", encoding="utf-8") as in_usfm_file:
         usfm_str = in_usfm_file.read()
-        all_markers_in_input =[find[1] for find in re.findall(r"\\((\w+\d*)(-[se])?)", usfm_str)]
+        all_markers_in_input =[find[0] for find in re.findall(r"\\((\w+\d*)(-[se])?)", usfm_str)]
     all_markers_in_input = list(set(all_markers_in_input))
     all_markers_in_input.remove("id")
-    all_markers_in_input.remove("c")
-    all_markers_in_input.remove("v")
+    if "esbe" in all_markers_in_input:
+        assert "esb" in all_markers_in_input
+        all_markers_in_input.remove("esbe")
         
     usfm_dict = test_parser.to_dict()
     all_json_keys = get_keys(usfm_dict)
     for marker in all_markers_in_input:
+        if marker.endswith("-s") or marker.endswith("-e") or marker.startswith("z"):
+            marker = "milestone"
         assert marker in all_json_keys, marker

--- a/python-usfm-parser/tests/test_json_conversion.py
+++ b/python-usfm-parser/tests/test_json_conversion.py
@@ -1,8 +1,8 @@
 '''Test the to_dict or json conversion API'''
-import re
 import pytest
 
-from tests import all_usfm_files, initialise_parser, doubtful_usfms, negative_tests
+from tests import all_usfm_files, initialise_parser, doubtful_usfms, negative_tests,\
+    find_all_markers
 
 test_files = all_usfm_files.copy()
 for file in doubtful_usfms+negative_tests:
@@ -37,14 +37,7 @@ def test_all_markers_are_in_output(file_path):
     test_parser = initialise_parser(file_path)
     assert not test_parser.errors, test_parser.errors
 
-    with open(file_path, "r", encoding="utf-8") as in_usfm_file:
-        usfm_str = in_usfm_file.read()
-        all_markers_in_input =[find[0] for find in re.findall(r"\\((\w+\d*)(-[se])?)", usfm_str)]
-    all_markers_in_input = list(set(all_markers_in_input))
-    all_markers_in_input.remove("id")
-    if "esbe" in all_markers_in_input:
-        assert "esb" in all_markers_in_input
-        all_markers_in_input.remove("esbe")
+    all_markers_in_input = find_all_markers(file_path)
         
     usfm_dict = test_parser.to_dict()
     all_json_keys = get_keys(usfm_dict)

--- a/python-usfm-parser/tests/test_list_conversion.py
+++ b/python-usfm-parser/tests/test_list_conversion.py
@@ -1,0 +1,19 @@
+'''Test the to_dict or json conversion API'''
+import pytest
+
+from tests import all_usfm_files, initialise_parser, doubtful_usfms, negative_tests
+from src.usfm_grammar import Filter
+
+test_files = all_usfm_files.copy()
+for file in doubtful_usfms+negative_tests:
+    if file in test_files:
+        test_files.remove(file)
+
+@pytest.mark.parametrize('file_path', test_files)
+@pytest.mark.timeout(30)
+def test_list_converions_without_filter(file_path):
+    '''Tests if input parses without errors'''
+    test_parser = initialise_parser(file_path)
+    assert not test_parser.errors, test_parser.errors
+    usfm_dict = test_parser.to_list([Filter.SCRIPTURE_TEXT])
+    assert isinstance(usfm_dict, list)

--- a/python-usfm-parser/tests/test_parsing.py
+++ b/python-usfm-parser/tests/test_parsing.py
@@ -1,8 +1,8 @@
 '''To test parsing success/errors for USFM/X committee's test suite'''
-import re
 import pytest
 
-from tests import all_usfm_files, initialise_parser, is_valid_usfm, doubtful_usfms, negative_tests
+from tests import all_usfm_files, initialise_parser, is_valid_usfm,\
+    doubtful_usfms, negative_tests, find_all_markers
 
 test_files = all_usfm_files.copy()
 for file in doubtful_usfms:
@@ -40,16 +40,7 @@ def test_all_markers_are_in_output(file_path):
     test_parser = initialise_parser(file_path)
     assert not test_parser.errors, test_parser.errors
 
-    all_markers_in_input = []
-    with open(file_path, "r", encoding="utf-8") as in_usfm_file:
-        usfm_str = in_usfm_file.read()
-        for find in re.findall(r"\\(([a-zA-Z]+)(\d*)(-[se])?)", usfm_str):
-            all_markers_in_input.append(find[1]) # No need of numbered part for checking ST
-    all_markers_in_input = list(set(all_markers_in_input))
-    all_markers_in_input.remove("id")
-    if "esbe" in all_markers_in_input:
-        assert "esb" in all_markers_in_input
-        all_markers_in_input.remove("esbe")
+    all_markers_in_input = find_all_markers(file_path, keep_number=False)
 
     all_nodes_in_st = get_nodes(test_parser.syntax_tree)
     for marker in all_markers_in_input:

--- a/tests/special-cases/empty-book/origin.usfm
+++ b/tests/special-cases/empty-book/origin.usfm
@@ -1,1 +1,1 @@
-\id SNG
+\id SNG 

--- a/tree-sitter-usfm3/grammar.js
+++ b/tree-sitter-usfm3/grammar.js
@@ -269,7 +269,7 @@ module.exports = grammar({
     b: $ => seq("\\b", $._spaceOrLine),
 
     //quotes
-    poetry: $ => choice(
+    poetry: $ => prec.right(0, repeat1(choice(
       $.qBlock,
       $.qr,
       $.qc,
@@ -278,7 +278,7 @@ module.exports = grammar({
       // $.qac,
       $.qmBlock,
       $.qd,
-    ),
+    ))),
 
     _poetryContent: $ => choice(
       $._paragraphContent,

--- a/tree-sitter-usfm3/test/corpus/test6_poetry.txt
+++ b/tree-sitter-usfm3/test/corpus/test6_poetry.txt
@@ -105,12 +105,10 @@ qr
           (v
             (verseNumber))
           (verseText
-            (text)))))
-    (poetry
+            (text))))
       (qr
         (verseText
-          (text))))
-    (poetry
+          (text)))
       (qBlock
         (q
           (qTag
@@ -118,12 +116,10 @@ qr
           (v
             (verseNumber))
           (verseText
-            (text)))))
-    (poetry
+            (text))))
       (qr
         (verseText
-          (text))))
-    (poetry
+          (text)))
       (qBlock
         (q
           (qTag
@@ -131,8 +127,7 @@ qr
           (v
             (verseNumber))
           (verseText
-            (text)))))
-    (poetry
+            (text))))
       (qr
         (verseText
           (text))))))
@@ -189,13 +184,11 @@ qc
             (numberedLevelMax3))
           (verseText
             (text))
-          (b))))
-    (poetry
+          (b)))
       (qc
         (verseText
           (text))
-        (b)))
-    (poetry
+        (b))
       (qBlock
         (q
           (qTag
@@ -565,8 +558,7 @@ qd
             (numberedLevelMax3))
           (verseText
             (text))
-          (b))))
-    (poetry
+          (b)))
       (qd
         (verseText
           (text))))))


### PR DESCRIPTION
This PR includes
- More tests and fixes in the context of #192 
   All markers in the input USFM are found using regex pattern and the outputs 
       * SyntaxTree, 
       * dict and 
       * USX 
    are searched for these markers to ensure all usfm components are represented in parsed output formats
- A grammar change to combine adjacent poetry elements within one "poetry" element in syntax tree and there by in JSON
- Changes in to_list() 
   - To accommodate for the change in dict for using `v` and `c` as keys instead of chapterNumber and verseNumber
   - Tests to make sure conversions happen without failure
   - Minor fixes to handle some failures
   - This methods needs to be re-written to work with the flat JSON schema. So, no further changes or tests done for now.
- A small change in Exception handling that was part of previous PR
- Four tests that use \k-s as milestone have been excludeda and noted, as I have doubt about the correctness of this usage.