### PR TITLE
Relaxed mode with "ignore_errors" option

### DIFF
--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Run tests for parsing errors
         working-directory: ./python-usfm-parser
         run:
-          pytest -k "not compare_usx_with_testsuite_samples and not testsuite_usx_with_rnc_grammar and not samples-from-wild" -n auto
+          pytest -k "not compare_usx_with_testsuite_samples and not testsuite_usx_with_rnc_grammar and not samples-from-wild and not 57-TIT.partial" -n auto

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -1,8 +1,8 @@
 name: Test.PyPI Publish
 
 on:
-  # push:
-  workflow_dispatch:
+  push:
+  # workflow_dispatch:
 
 jobs:
   build_wheels:

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -1,10 +1,8 @@
-name: PyPI Publish
+name: Test.PyPI Publish
 
 on:
   # push:
   workflow_dispatch:
-  release:
-    types: [published]
 
 jobs:
   build_wheels:
@@ -57,10 +55,10 @@ jobs:
           name: artifact
           path: python-usfm-parser/dist/
 
-      - name: Publish distribution 📦 to PyPI
+      - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.pypi_token }}
-          # repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PUBLISH_ON_TEST_PYPI }}
+          repository_url: https://test.pypi.org/legacy/
           packages_dir: python-usfm-parser/dist/

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -1,8 +1,8 @@
 name: Test.PyPI Publish
 
 on:
-  push:
-  # workflow_dispatch:
+  # push: # need to use this temporarly to be able to publish
+  workflow_dispatch: # works only on default branch
 
 jobs:
   build_wheels:

--- a/python-usfm-parser/.bumpversion.cfg
+++ b/python-usfm-parser/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-alpha.5
+current_version = 3.0.0-alpha.29
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-(?P<release>\w+).(?P<num>\d+)

--- a/python-usfm-parser/.bumpversion.cfg
+++ b/python-usfm-parser/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-alpha.29
+current_version = 3.0.0-alpha.6
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-(?P<release>\w+).(?P<num>\d+)

--- a/python-usfm-parser/pyproject.toml
+++ b/python-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.0-alpha.5"
+version = "3.0.0-alpha.29"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]

--- a/python-usfm-parser/pyproject.toml
+++ b/python-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.0-alpha.29"
+version = "3.0.0-alpha.6"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]

--- a/python-usfm-parser/setup.py
+++ b/python-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.0-alpha.29",  # Required
+    version="3.0.0-alpha.6",  # Required
     python_requires=">=3.10",
     install_requires=["tree-sitter", "lxml"],  # Optional
     package_data={  # Optional

--- a/python-usfm-parser/setup.py
+++ b/python-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.0-alpha.5",  # Required
+    version="3.0.0-alpha.29",  # Required
     python_requires=">=3.10",
     install_requires=["tree-sitter", "lxml"],  # Optional
     package_data={  # Optional

--- a/python-usfm-parser/src/usfm_grammar/__init__.py
+++ b/python-usfm-parser/src/usfm_grammar/__init__.py
@@ -6,4 +6,4 @@ Filter = usfm_parser.Filter
 Format = usfm_parser.Format
 USFMParser = usfm_parser.USFMParser
 
-__version__ = "3.0.0-alpha.5"
+__version__ = "3.0.0-alpha.29"

--- a/python-usfm-parser/src/usfm_grammar/__init__.py
+++ b/python-usfm-parser/src/usfm_grammar/__init__.py
@@ -6,4 +6,4 @@ Filter = usfm_parser.Filter
 Format = usfm_parser.Format
 USFMParser = usfm_parser.USFMParser
 
-__version__ = "3.0.0-alpha.29"
+__version__ = "3.0.0-alpha.6"

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -53,23 +53,23 @@ def main():
 
     match output_format:
         case Format.JSON:
-            dict_output = my_parser.to_dict(filters=updated_filt)
+            dict_output = my_parser.to_dict(filters=updated_filt, ignore_errors=True)
             print(json.dumps(dict_output, indent=4, ensure_ascii=False))
         case Format.CSV:
-            table_output = my_parser.to_list(filters = updated_filt)
+            table_output = my_parser.to_list(filters = updated_filt, ignore_errors=True)
             outfile = sys.stdout
             writer = csv.writer(outfile,
                 delimiter=arg_parser.parse_args().csv_col_sep,
                 lineterminator=arg_parser.parse_args().csv_row_sep)
             writer.writerows(table_output)
         case Format.USX:
-            xmlstr = etree.tostring(my_parser.to_usx(),
+            xmlstr = etree.tostring(my_parser.to_usx(ignore_errors=True),
                 encoding='unicode', pretty_print=True)
             print(xmlstr)
         case Format.MD:
             print(my_parser.to_markdown())
         case Format.ST:
-            print(my_parser.to_syntax_tree())
+            print(my_parser.to_syntax_tree(ignore_errors=True))
         case _:
             raise Exception(f"Un-recognized output format:{output_format}!")
 

--- a/python-usfm-parser/src/usfm_grammar/__main__.py
+++ b/python-usfm-parser/src/usfm_grammar/__main__.py
@@ -26,6 +26,9 @@ def main():
     arg_parser.add_argument('--csv_row_sep', type=str,
                             help="row separator or delimiter. Only useful with format=table.",
                             default="\n")
+    arg_parser.add_argument('--ignore_errors',
+                            help="to get some output from successfully parsed portions",
+                            action='store_true')
 
     infile = arg_parser.parse_args().infile
     output_format = arg_parser.parse_args().format
@@ -36,7 +39,7 @@ def main():
 
     my_parser = USFMParser(file_content)
 
-    if my_parser.errors:
+    if my_parser.errors and not arg_parser.parse_args().ignore_errors:
         err_str = "\n\t".join([":".join(err) for err in my_parser.errors])
         print(f"Errors present:\n\t{err_str}")
         sys.exit(1)

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -522,7 +522,7 @@ def node_2_dict_generic(node, usfm_bytes, filters): # pylint: disable=R0912
         result['attributes'] = attribs
     if closing_node is not None:
         result['closing'] = usfm_bytes[\
-            closing_node.start_byte:closing_node.end_byte].decode('utf-8').strip()
+            closing_node.start_byte:closing_node.end_byte].decode('utf-8').strip().replace("\\","")
     return result
 
 @reduce_nesting

--- a/python-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/python-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -722,12 +722,22 @@ class USFMParser():
                                     for err in errors]
 
 
-    def to_syntax_tree(self):
+    def to_syntax_tree(self, ignore_errors=False):
         '''gives the syntax tree from class, as a string'''
+        if not ignore_errors and self.errors:
+            err_str = "\n\t".join([":".join(err) for err in self.errors])
+            raise Exception("Errors present:"+\
+                f'\n\t{err_str}'+\
+                "\nUse ignore_errors=True, to generate output inspite of errors")
         return self.syntax_tree.sexp()
 
-    def to_dict(self, filters=None): #pylint: disable=too-many-branches
+    def to_dict(self, filters=None, ignore_errors=False): #pylint: disable=too-many-branches
         '''Converts syntax tree to dictionary/json and selection of desired type of contents'''
+        if (not ignore_errors) and self.errors:
+            err_str = "\n\t".join([":".join(err) for err in self.errors])
+            raise Exception("Errors present:"+\
+                f'\n\t{err_str}'+\
+                "\nUse ignore_errors=True, to generate output inspite of errors")
         dict_output = {"book":{}}
         if filters is None or filters == []:
             filters = list(Filter)
@@ -775,14 +785,20 @@ class USFMParser():
             raise Exception(message)  from exe
         return dict_output
 
-    def to_list(self, filters=None): # pylint: disable=too-many-branches
+    def to_list(self, filters=None, ignore_errors=False): # pylint: disable=too-many-branches, too-many-locals
         '''uses the toJSON function and converts JSON to CSV
         To be re-implemented to work with the flat JSON schema'''
+        if not ignore_errors and self.errors:
+            err_str = "\n\t".join([":".join(err) for err in self.errors])
+            raise Exception("Errors present:"+\
+                f'\n\t{err_str}'+\
+                "\nUse ignore_errors=True, to generate output inspite of errors")
+
         if filters is None:
             filters = list(Filter)
         if Filter.PARAGRAPHS in filters:
             filters.remove(Filter.PARAGRAPHS)
-        scripture_json = self.to_dict(filters)
+        scripture_json = self.to_dict(filters, ignore_errors=ignore_errors)
         table_output = [["Book","Chapter","Verse","Verse-Text","Notes","Milestone","Other"]]
         book = scripture_json['book']['bookCode']
         verse_num = 0
@@ -831,8 +847,15 @@ class USFMParser():
         return "yet to be implemeneted"
 
 
-    def to_usx(self):
+    def to_usx(self, ignore_errors=False):
         '''convert the syntax_tree to the XML format USX'''
+        if not ignore_errors and self.errors:
+            err_str = "\n\t".join([":".join(err) for err in self.errors])
+            raise Exception("Errors present:"+\
+                f'\n\t{err_str}'+\
+                "\nUse ignore_errors=True, to generate output inspite of errors")
+
+
         usx_root = etree.Element("usx")
         usx_root.set("version", "3.0")
         try:


### PR DESCRIPTION
This PR includes
- Use of `ignore_errors` option on CLI and in class methods. #200 
- Tests for the above feature
- Removed slash from the closing markers in dict/JSON output
Before: 
```
{  "w": "verse",
    "attributes": [ { "lemma": "gloassary entry"} ],
    "closing": "\\w*"   }
```
After:

```
{  "w": "verse",
    "attributes": [ { "lemma": "gloassary entry"} ],
    "closing": "w*"   }
```
- A new gitactions workflow to do test publishing on test.pypi
- Ignoring a long file that takes more than 30s to convert to dict
- Version number change for next publishing on PyPi