### PR TITLE
Bugfix 204 extracting versetext from li

### DIFF
--- a/js/grammarOperations.js
+++ b/js/grammarOperations.js
@@ -70,12 +70,18 @@ function buildVerseText(elmts) {
       for (let j = 0; j < elmts[key].length; j += 1) {
         const innerKey = Object.keys(elmts[key][j])[0];
         if (elmts[key][j][innerKey] !== null) {
+          let listText = '';
+          if (typeof elmts[key][j][innerKey] === 'string'){
+            listText = elmts[key][j][innerKey];
+          }else{
+            listText = buildVerseText(elmts[key][j][innerKey]);
+          }
           if (punctPattern1.test(elmts[key][j][innerKey])
             || punctPattern2.test(verseTextPartial)
             || verseTextPartial.endsWith(' ') || verseTextPartial === '') {
-            verseTextPartial += elmts[key][j][innerKey];
+            verseTextPartial += listText;
           } else {
-            verseTextPartial += ` ${elmts[key][j][innerKey]}`;
+            verseTextPartial += ` ${listText}`;
           }
         }
       }

--- a/js/grammarOperations.js
+++ b/js/grammarOperations.js
@@ -71,9 +71,9 @@ function buildVerseText(elmts) {
         const innerKey = Object.keys(elmts[key][j])[0];
         if (elmts[key][j][innerKey] !== null) {
           let listText = '';
-          if (typeof elmts[key][j][innerKey] === 'string'){
+          if (typeof elmts[key][j][innerKey] === 'string') {
             listText = elmts[key][j][innerKey];
-          }else{
+          } else {
             listText = buildVerseText(elmts[key][j][innerKey]);
           }
           if (punctPattern1.test(elmts[key][j][innerKey])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "usfm-grammar",
     "description": "An elegant [USFM](https://github.com/ubsicap/usfm) parser (or validator) that uses a [parsing expression grammar](https://en.wikipedia.org/wiki/Parsing_expression_grammar) to model USFM. The grammar is written using [ohm](https://ohmlang.github.io/). Only USFM 3.0 is supported. The parsed USFM is an intuitive and easy to manipulate JSON structure that allows for painless extraction of scripture and other content from the markup. USFM Grammar is also capable of reconverting the generated JSON back to USFM.",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "main": "./js/main.js",
     "scripts": {
         "test": "mocha --expose-gc --timeout 40000",

--- a/test/test_bugFixes.js
+++ b/test/test_bugFixes.js
@@ -372,4 +372,17 @@ describe('Test bug fixes', () => {
     const relaxedJsonOutput = usfmParserRelaxed.toJSON();
     assert.strictEqual(relaxedJsonOutput.chapters[0].contents[1].verseText, 'जब अम्मोनियों ने देखा, कि हम दाऊद को घिनौने लगते हैं, तब हानून और अम्मोनियों ने एक हजार किक्कार चाँदी , अरम्नहरैम और अरम्माका और सोबा को भेजी, कि रथ और सवार किराये पर बुलाए।');
   });
+
+  it('204-extracting-versetext-from-li', () => {
+    // https://github.com/Bridgeconn/usfm-grammar/issues/204
+    const inputUsfm = '\\id GEN\n\\c 1\n\\p\n\\v 19 \\w These|strong="H0428"\\w* \\w are|strong="H0428"\\w* \\w the|strong="H8034"\\w* \\w names|strong="H8034"\\w* \\w of|strong="H1121"\\w* \\w the|strong="H8034"\\w* leaders: \n\\b\n\\li1 \\w from|strong="H0376"\\w* \\w the|strong="H8034"\\w* \\w tribe|strong="H4294"\\w* \\w of|strong="H1121"\\w* \\w Judah|strong="H3063"\\w*—\\w Caleb|strong="H3612"\\w* \\w son|strong="H1121"\\w* \\w of|strong="H1121"\\w* \\w Jephunneh|strong="H3312"\\w*; \n\\li1 \n\\v 20 \\w from|strong="H1121"\\w* \\w the|strong="H1121"\\w* \\w tribe|strong="H4294"\\w* \\w of|strong="H1121"\\w* \\w Simeon|strong="H8095"\\w*—\\w Shemuel|strong="H8050"\\w* \\w son|strong="H1121"\\w* \\w of|strong="H1121"\\w* \\w Ammihud|strong="H5989"\\w*;';
+    const usfmParser = new grammar.USFMParser(inputUsfm);
+    const jsonOutput = usfmParser.toJSON();
+    assert.strictEqual(jsonOutput.chapters[0].contents[1].verseText, 'These are the names of the leaders: from the tribe of Judah—Caleb son of Jephunneh; 1');
+    assert.strictEqual(jsonOutput.chapters[0].contents[2].verseText, 'from the tribe of Simeon—Shemuel son of Ammihud;');
+    const usfmParserRelaxed = new grammar.USFMParser(inputUsfm, grammar.LEVEL.RELAXED);
+    const relaxedJsonOutput = usfmParserRelaxed.toJSON();
+    assert.strictEqual(relaxedJsonOutput.chapters[0].contents[1].verseText, 'These are the names of the leaders: from the tribe of Judah—Caleb son of Jephunneh;');
+    assert.strictEqual(relaxedJsonOutput.chapters[0].contents[2].verseText, 'from the tribe of Simeon—Shemuel son of Ammihud;');
+  });
 });


### PR DESCRIPTION
- Fixes #204 
The issue was occuring due to complex markups where `\w`s were present within text in `\li` and the texts coming within these `\w`s were not being extracted as verseText
- Also changes the version number to `2.3.1` for next release