### PR TITLE
Feature/185 filtering on usj

### DIFF
--- a/docs/API guide for python usfm_grammar.ipynb
+++ b/docs/API guide for python usfm_grammar.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -e ./../python-usfm-parser/ # from the code base"
+    "! pip install -e ./../py-usfm-parser/ # from the code base"
    ]
   },
   {
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "5d06e40a",
    "metadata": {},
    "outputs": [],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "932320b5",
    "metadata": {},
    "outputs": [],
@@ -133,7 +133,7 @@
     "\\\\tr \\\\tcr1 2nd \\\\tc2 Issachar \\\\tc3 Nethanel son of Zuar\n",
     "\\\\tr \\\\tcr1 3rd \\\\tc2 Zebulun \\\\tc3 Eliab son of Helon\n",
     "\\\\p\n",
-    "\\\\v 5 യാക്കോബിന്റെ സന്താനപരമ്പരകൾ എല്ലാം കൂടി എഴുപതു പേർ ആയിരുന്നു; യോസേഫ് മുമ്പെ തന്നെ ഈജിപ്റ്റിൽ ആയിരുന്നു. \\w gracious|grace\\w* and then a few words later \\w gracious|lemma=\"grace\" x-myattr=\"metadata\"\\w*\n",
+    "\\\\v 5 യാക്കോബിന്റെ സന്താനപരമ്പരകൾ എല്ലാം കൂടി എഴുപതു പേർ ആയിരുന്നു; യോസേഫ് മുമ്പെ തന്നെ ഈജിപ്റ്റിൽ ആയിരുന്നു. \\\\w gracious \\\\+nd Lord\\\\+nd*|grace\\\\w* and then a few words later \\w gracious|lemma=\"grace\" x-myattr=\"metadata\"\\w*\n",
     "\\\\c 2\n",
     "\\\\s1 A Prayer of Habakkuk\n",
     "\\\\p\n",
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "ad92e648",
    "metadata": {},
    "outputs": [],
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "758fc216",
    "metadata": {},
    "outputs": [],
@@ -202,10 +202,145 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "9aa16315",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'USJ',\n",
+       " 'version': '0.1.0',\n",
+       " 'content': [{'type': 'book:id',\n",
+       "   'content': ['02EXOGNT92.SFM, Good News Translation, June 2003'],\n",
+       "   'code': 'EXO'},\n",
+       "  {'type': 'para:h', 'content': ['പുറപ്പാടു്']},\n",
+       "  {'type': 'para:toc1', 'content': ['പുറപ്പാടു്']},\n",
+       "  {'type': 'para:toc2', 'content': ['പുറപ്പാടു്']},\n",
+       "  {'type': 'para:mt', 'content': ['പുറപ്പാടു്']},\n",
+       "  {'type': 'chapter:c', 'number': '1', 'sid': 'EXO 1'},\n",
+       "  {'type': 'para:p',\n",
+       "   'content': [{'type': 'verse:v', 'number': '1', 'sid': 'EXO 1:1'},\n",
+       "    'യാക്കോബിനോടുകൂടെ കുടുംബസഹിതം ഈജിപ്റ്റിൽ വന്ന']},\n",
+       "  {'type': 'para:p',\n",
+       "   'content': ['യിസ്രായേൽമക്കളുടെ പേരുകൾ :',\n",
+       "    {'type': 'verse:v', 'number': '2', 'sid': 'EXO 1:2'},\n",
+       "    'രൂബേൻ, ശിമെയോൻ, ലേവി,',\n",
+       "    {'type': 'verse:v', 'number': '3', 'sid': 'EXO 1:3'}]},\n",
+       "  {'type': 'para:li1', 'content': ['യെഹൂദാ,']},\n",
+       "  {'type': 'para:li1', 'content': ['യിസ്സാഖാർ,']},\n",
+       "  {'type': 'para:li1', 'content': ['സെബൂലൂൻ,']},\n",
+       "  {'type': 'para:li1', 'content': ['ബെന്യാമീൻ']},\n",
+       "  {'type': 'para:p',\n",
+       "   'content': [{'type': 'verse:v', 'number': '4', 'sid': 'EXO 1:4'},\n",
+       "    'ദാൻ, നഫ്താലി, ഗാദ്, ആശേർ.',\n",
+       "    {'type': 'verse:v', 'number': '12-83', 'sid': 'EXO 1:12-83'},\n",
+       "    'They presented their offerings in the following order:']},\n",
+       "  {'type': 'table',\n",
+       "   'content': [{'type': 'table:row:tr',\n",
+       "     'content': [{'type': 'table:cell:th1',\n",
+       "       'content': ['Day'],\n",
+       "       'align': 'start'},\n",
+       "      {'type': 'table:cell:th2', 'content': ['Tribe'], 'align': 'start'},\n",
+       "      {'type': 'table:cell:th3', 'content': ['Leader'], 'align': 'start'}]},\n",
+       "    {'type': 'table:row:tr',\n",
+       "     'content': [{'type': 'table:cell:tcr1',\n",
+       "       'content': ['1st'],\n",
+       "       'align': 'end'},\n",
+       "      {'type': 'table:cell:tc2', 'content': ['Judah'], 'align': 'start'},\n",
+       "      {'type': 'table:cell:tc3',\n",
+       "       'content': ['Nahshon son of Amminadab'],\n",
+       "       'align': 'start'}]},\n",
+       "    {'type': 'table:row:tr',\n",
+       "     'content': [{'type': 'table:cell:tcr1',\n",
+       "       'content': ['2nd'],\n",
+       "       'align': 'end'},\n",
+       "      {'type': 'table:cell:tc2', 'content': ['Issachar'], 'align': 'start'},\n",
+       "      {'type': 'table:cell:tc3',\n",
+       "       'content': ['Nethanel son of Zuar'],\n",
+       "       'align': 'start'}]},\n",
+       "    {'type': 'table:row:tr',\n",
+       "     'content': [{'type': 'table:cell:tcr1',\n",
+       "       'content': ['3rd'],\n",
+       "       'align': 'end'},\n",
+       "      {'type': 'table:cell:tc2', 'content': ['Zebulun'], 'align': 'start'},\n",
+       "      {'type': 'table:cell:tc3',\n",
+       "       'content': ['Eliab son of Helon'],\n",
+       "       'align': 'start'}]}]},\n",
+       "  {'type': 'para:p',\n",
+       "   'content': [{'type': 'verse:v', 'number': '5', 'sid': 'EXO 1:5'},\n",
+       "    'യാക്കോബിന്റെ സന്താനപരമ്പരകൾ എല്ലാം കൂടി എഴുപതു പേർ ആയിരുന്നു; യോസേഫ് മുമ്പെ തന്നെ ഈജിപ്റ്റിൽ ആയിരുന്നു.',\n",
+       "    {'type': 'char:w',\n",
+       "     'content': ['gracious', {'type': 'char:nd', 'content': ['Lord']}],\n",
+       "     'lemma': 'grace'},\n",
+       "    'and then a few words later',\n",
+       "    {'type': 'char:w',\n",
+       "     'content': ['gracious'],\n",
+       "     'lemma': 'grace',\n",
+       "     'x-myattr': 'metadata'},\n",
+       "    '']},\n",
+       "  {'type': 'chapter:c', 'number': '2', 'sid': 'EXO 2'},\n",
+       "  {'type': 'para:s1', 'content': ['A Prayer of Habakkuk']},\n",
+       "  {'type': 'para:p',\n",
+       "   'content': [{'type': 'verse:v', 'number': '1', 'sid': 'EXO 2:1'},\n",
+       "    'This is a prayer of the prophet Habakkuk:',\n",
+       "    {'type': 'optbreak:b'}]},\n",
+       "  {'type': 'para:q1',\n",
+       "   'content': [{'type': 'verse:v', 'number': '2', 'sid': 'EXO 2:2'},\n",
+       "    'O',\n",
+       "    {'type': 'char:nd', 'content': ['Lord']},\n",
+       "    ', I have heard of what you have done,']},\n",
+       "  {'type': 'para:q2', 'content': ['and I am filled with awe.']},\n",
+       "  {'type': 'para:q1', 'content': ['Now do again in our times']},\n",
+       "  {'type': 'para:q2', 'content': ['the great deeds you used to do.']},\n",
+       "  {'type': 'para:q1', 'content': ['Be merciful, even when you are angry.']},\n",
+       "  {'type': 'para:p',\n",
+       "   'content': [{'type': 'verse:v', 'number': '20', 'sid': 'EXO 2:20'},\n",
+       "    'Adam',\n",
+       "    {'type': 'note:f',\n",
+       "     'content': ['',\n",
+       "      {'type': 'char:fr', 'content': ['3.20:']},\n",
+       "      {'type': 'char:fk', 'content': ['Adam:']},\n",
+       "      {'type': 'char:ft',\n",
+       "       'content': ['This name in Hebrew means “all human beings.”']}],\n",
+       "     'caller': '+'},\n",
+       "    'named his wife Eve,',\n",
+       "    {'type': 'note:f',\n",
+       "     'content': ['',\n",
+       "      {'type': 'char:fr', 'content': ['3.20:']},\n",
+       "      {'type': 'char:fk', 'content': ['Eve:']},\n",
+       "      {'type': 'char:ft',\n",
+       "       'content': ['This name sounds similar to the Hebrew\\nword for “living,” which is rendered in this context as “human beings.”']}],\n",
+       "     'caller': '+'},\n",
+       "    'because she\\nwas the mother of all human beings.',\n",
+       "    {'type': 'verse:v', 'number': '21', 'sid': 'EXO 2:21'},\n",
+       "    'And the',\n",
+       "    {'type': 'char:nd', 'content': ['Lord']},\n",
+       "    'God made clothes out of animal skins for Adam and his wife,\\nand he clothed them.',\n",
+       "    {'type': 'ms:qt-s', 'sid': 'qt_123', 'who': 'Pilate'},\n",
+       "    '“Are you the king of the Jews?”',\n",
+       "    {'type': 'ms:qt-e', 'eid': 'qt_123'},\n",
+       "    '']},\n",
+       "  {'type': 'sidebar:esb',\n",
+       "   'content': [{'type': 'para:ms', 'content': ['Fish and Fishing']},\n",
+       "    {'type': 'para:p',\n",
+       "     'content': [\"In Jesus' time, fishing took place mostly on lake Galilee, because Jewish people\\ncould not use many of the harbors along the coast of the Mediterranean Sea, since these\\nharbors were often controlled by unfriendly neighbors. The most common fish in the Lake\\nof Galilee were carp and catfish.\",\n",
+       "      {'type': 'char:wj', 'content': ['The Law of Moses']},\n",
+       "      'allowed people to eat any fish with\\nfins and scales, but since catfish lack scales (as do eels and sharks) they were not to\\nbe eaten. Fish were also probably brought from Tyre and Sidon,\\nwhere they were dried and salted.\\n...']},\n",
+       "    {'type': 'para:p',\n",
+       "     'content': ['Among early Christians, the fish was a favorite image for Jesus, because the Greek\\nword for fish (',\n",
+       "      {'type': 'char:tl', 'content': ['ichthus']},\n",
+       "      ') consists of the first letters of the Greek words that\\ntell who Jesus is:',\n",
+       "      {'type': 'figure:fig', 'content': ['Christian Fish Image']},\n",
+       "      '']}],\n",
+       "   'category': 'History'}]}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_parser.to_usj()"
    ]
@@ -217,17 +352,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# my_parser.to_dict([Filter.SCRIPTURE_TEXT])"
+    "my_parser.to_usj(exclude_markers=['s1','h', 'toc1','toc2','mt','b', #inner contents gone\n",
+    "                                  'p','q1','q2', # inner content got preserved and moved one layer up(falttened)\n",
+    "                                  'w','nd',# inner content got preserved...\n",
+    "                                  'tr','tc2','tcr1', 'tc3', 'th1','th2', 'th3','table',# inner content got preserved...\n",
+    "                                  'li1', # inner content got preserved...\n",
+    "                                  'esb','f', #inner contents gone\n",
+    "                                 ],\n",
+    "                 # combine_texts=False\n",
+    "                )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "ba0b92d5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'USJ',\n",
+       " 'version': '0.1.0',\n",
+       " 'content': [{'type': 'book:id',\n",
+       "   'content': ['02EXOGNT92.SFM, Good News Translation, June 2003'],\n",
+       "   'code': 'EXO'},\n",
+       "  {'type': 'chapter:c', 'number': '1', 'sid': 'EXO 1', 'content': []},\n",
+       "  {'type': 'verse:v', 'number': '1', 'sid': 'EXO 1:1', 'content': []},\n",
+       "  'യാക്കോബിനോടുകൂടെ കുടുംബസഹിതം ഈജിപ്റ്റിൽ വന്ന യിസ്രായേൽമക്കളുടെ പേരുകൾ :',\n",
+       "  {'type': 'verse:v', 'number': '2', 'sid': 'EXO 1:2', 'content': []},\n",
+       "  'രൂബേൻ, ശിമെയോൻ, ലേവി,',\n",
+       "  {'type': 'verse:v', 'number': '3', 'sid': 'EXO 1:3', 'content': []},\n",
+       "  'യെഹൂദാ, യിസ്സാഖാർ, സെബൂലൂൻ, ബെന്യാമീൻ',\n",
+       "  {'type': 'verse:v', 'number': '4', 'sid': 'EXO 1:4', 'content': []},\n",
+       "  'ദാൻ, നഫ്താലി, ഗാദ്, ആശേർ.',\n",
+       "  {'type': 'verse:v', 'number': '12-83', 'sid': 'EXO 1:12-83', 'content': []},\n",
+       "  'They presented their offerings in the following order: Day Tribe Leader 1st Judah Nahshon son of Amminadab 2nd Issachar Nethanel son of Zuar 3rd Zebulun Eliab son of Helon',\n",
+       "  {'type': 'verse:v', 'number': '5', 'sid': 'EXO 1:5', 'content': []},\n",
+       "  'യാക്കോബിന്റെ സന്താനപരമ്പരകൾ എല്ലാം കൂടി എഴുപതു പേർ ആയിരുന്നു; യോസേഫ് മുമ്പെ തന്നെ ഈജിപ്റ്റിൽ ആയിരുന്നു. gracious Lord and then a few words later gracious ',\n",
+       "  {'type': 'chapter:c', 'number': '2', 'sid': 'EXO 2', 'content': []},\n",
+       "  {'type': 'verse:v', 'number': '1', 'sid': 'EXO 2:1', 'content': []},\n",
+       "  'This is a prayer of the prophet Habakkuk:',\n",
+       "  {'type': 'verse:v', 'number': '2', 'sid': 'EXO 2:2', 'content': []},\n",
+       "  'O Lord, I have heard of what you have done, and I am filled with awe. Now do again in our times the great deeds you used to do. Be merciful, even when you are angry.',\n",
+       "  {'type': 'verse:v', 'number': '20', 'sid': 'EXO 2:20', 'content': []},\n",
+       "  'Adam named his wife Eve, because she\\nwas the mother of all human beings.',\n",
+       "  {'type': 'verse:v', 'number': '21', 'sid': 'EXO 2:21', 'content': []},\n",
+       "  'And the Lord God made clothes out of animal skins for Adam and his wife,\\nand he clothed them. “Are you the king of the Jews?” ']}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# my_parser.to_dict([Filter.NOTES])"
+    "my_parser.to_usj(include_markers=Filter.BCV+Filter.TEXT,\n",
+    "                 combine_texts=True\n",
+    "                )"
    ]
   },
   {
@@ -237,26 +419,152 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# my_parser.to_dict([Filter.SCRIPTURE_TEXT, Filter.PARAGRAPHS, Filter.TITLES])"
+    "my_parser.to_usj(exclude_markers=Filter.BOOK_HEADERS+Filter.TITLES+Filter.COMMENTS,\n",
+    "                 # combine_texts=False\n",
+    "                )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf59a547",
+   "id": "20054f9a-4113-4537-83ff-f31768727f14",
    "metadata": {},
    "outputs": [],
    "source": [
-    "table_output = my_parser.to_list()\n",
-    "table_output\n"
+    "# For a Flattened JSON\n",
+    "my_parser.to_usj(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS\n",
+    "                 # combine_texts=False\n",
+    "                )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f56bc71d",
+   "id": "e4e5d1fd-203f-41b3-9c88-4f9807b445d8",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "Filter.PARAGRAPHS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed65d7d6-71b3-4cc0-b524-017e913245df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For eliminating the Text as well from the excluded markers(here, pargraphs and characters)\n",
+    "my_parser.to_usj(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS+Filter.TEXT\n",
+    "                 # combine_texts=False\n",
+    "                )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cf59a547",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "table_output = my_parser.to_list()\n",
+    "# table_output\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f56bc71d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Book\tChapter\tVerse\tText\tType\n",
+      "EXO\t\t\t02EXOGNT92.SFM, Good News Translation, June 2003\tbook:id\n",
+      "EXO\t\t\tപുറപ്പാടു്\tpara:h\n",
+      "EXO\t\t\tപുറപ്പാടു്\tpara:toc1\n",
+      "EXO\t\t\tപുറപ്പാടു്\tpara:toc2\n",
+      "EXO\t\t\tപുറപ്പാടു്\tpara:mt\n",
+      "EXO\t1\t1\tയാക്കോബിനോടുകൂടെ കുടുംബസഹിതം ഈജിപ്റ്റിൽ വന്ന\tpara:p\n",
+      "EXO\t1\t1\tയിസ്രായേൽമക്കളുടെ പേരുകൾ :\tpara:p\n",
+      "EXO\t1\t2\tരൂബേൻ, ശിമെയോൻ, ലേവി,\tpara:p\n",
+      "EXO\t1\t3\tയെഹൂദാ,\tpara:li1\n",
+      "EXO\t1\t3\tയിസ്സാഖാർ,\tpara:li1\n",
+      "EXO\t1\t3\tസെബൂലൂൻ,\tpara:li1\n",
+      "EXO\t1\t3\tബെന്യാമീൻ\tpara:li1\n",
+      "EXO\t1\t4\tദാൻ, നഫ്താലി, ഗാദ്, ആശേർ.\tpara:p\n",
+      "EXO\t1\t12-83\tThey presented their offerings in the following order:\tpara:p\n",
+      "EXO\t1\t12-83\tDay\ttable:cell:th1\n",
+      "EXO\t1\t12-83\tTribe\ttable:cell:th2\n",
+      "EXO\t1\t12-83\tLeader\ttable:cell:th3\n",
+      "EXO\t1\t12-83\t1st\ttable:cell:tcr1\n",
+      "EXO\t1\t12-83\tJudah\ttable:cell:tc2\n",
+      "EXO\t1\t12-83\tNahshon son of Amminadab\ttable:cell:tc3\n",
+      "EXO\t1\t12-83\t2nd\ttable:cell:tcr1\n",
+      "EXO\t1\t12-83\tIssachar\ttable:cell:tc2\n",
+      "EXO\t1\t12-83\tNethanel son of Zuar\ttable:cell:tc3\n",
+      "EXO\t1\t12-83\t3rd\ttable:cell:tcr1\n",
+      "EXO\t1\t12-83\tZebulun\ttable:cell:tc2\n",
+      "EXO\t1\t12-83\tEliab son of Helon\ttable:cell:tc3\n",
+      "EXO\t1\t5\tയാക്കോബിന്റെ സന്താനപരമ്പരകൾ എല്ലാം കൂടി എഴുപതു പേർ ആയിരുന്നു; യോസേഫ് മുമ്പെ തന്നെ ഈജിപ്റ്റിൽ ആയിരുന്നു.\tpara:p\n",
+      "EXO\t1\t5\tgracious\tchar:w\n",
+      "EXO\t1\t5\tLord\tchar:nd\n",
+      "EXO\t1\t5\tand then a few words later\tpara:p\n",
+      "EXO\t1\t5\tgracious\tchar:w\n",
+      "EXO\t1\t5\t\tpara:p\n",
+      "EXO\t2\t5\tA Prayer of Habakkuk\tpara:s1\n",
+      "EXO\t2\t1\tThis is a prayer of the prophet Habakkuk:\tpara:p\n",
+      "EXO\t2\t2\tO\tpara:q1\n",
+      "EXO\t2\t2\tLord\tchar:nd\n",
+      "EXO\t2\t2\t, I have heard of what you have done,\tpara:q1\n",
+      "EXO\t2\t2\tand I am filled with awe.\tpara:q2\n",
+      "EXO\t2\t2\tNow do again in our times\tpara:q1\n",
+      "EXO\t2\t2\tthe great deeds you used to do.\tpara:q2\n",
+      "EXO\t2\t2\tBe merciful, even when you are angry.\tpara:q1\n",
+      "EXO\t2\t20\tAdam\tpara:p\n",
+      "EXO\t2\t20\t\tnote:f\n",
+      "EXO\t2\t20\t3.20:\tchar:fr\n",
+      "EXO\t2\t20\tAdam:\tchar:fk\n",
+      "EXO\t2\t20\tThis name in Hebrew means “all human beings.”\tchar:ft\n",
+      "EXO\t2\t20\tnamed his wife Eve,\tpara:p\n",
+      "EXO\t2\t20\t\tnote:f\n",
+      "EXO\t2\t20\t3.20:\tchar:fr\n",
+      "EXO\t2\t20\tEve:\tchar:fk\n",
+      "EXO\t2\t20\tThis name sounds similar to the Hebrew\n",
+      "word for “living,” which is rendered in this context as “human beings.”\tchar:ft\n",
+      "EXO\t2\t20\tbecause she\n",
+      "was the mother of all human beings.\tpara:p\n",
+      "EXO\t2\t21\tAnd the\tpara:p\n",
+      "EXO\t2\t21\tLord\tchar:nd\n",
+      "EXO\t2\t21\tGod made clothes out of animal skins for Adam and his wife,\n",
+      "and he clothed them.\tpara:p\n",
+      "EXO\t2\t21\t“Are you the king of the Jews?”\tpara:p\n",
+      "EXO\t2\t21\t\tpara:p\n",
+      "EXO\t2\t21\tFish and Fishing\tpara:ms\n",
+      "EXO\t2\t21\tIn Jesus' time, fishing took place mostly on lake Galilee, because Jewish people\n",
+      "could not use many of the harbors along the coast of the Mediterranean Sea, since these\n",
+      "harbors were often controlled by unfriendly neighbors. The most common fish in the Lake\n",
+      "of Galilee were carp and catfish.\tpara:p\n",
+      "EXO\t2\t21\tThe Law of Moses\tchar:wj\n",
+      "EXO\t2\t21\tallowed people to eat any fish with\n",
+      "fins and scales, but since catfish lack scales (as do eels and sharks) they were not to\n",
+      "be eaten. Fish were also probably brought from Tyre and Sidon,\n",
+      "where they were dried and salted.\n",
+      "...\tpara:p\n",
+      "EXO\t2\t21\tAmong early Christians, the fish was a favorite image for Jesus, because the Greek\n",
+      "word for fish (\tpara:p\n",
+      "EXO\t2\t21\tichthus\tchar:tl\n",
+      "EXO\t2\t21\t) consists of the first letters of the Greek words that\n",
+      "tell who Jesus is:\tpara:p\n",
+      "EXO\t2\t21\tChristian Fish Image\tfigure:fig\n",
+      "EXO\t2\t21\t\tpara:p\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"\\n\".join([\"\\t\".join(row) for row in table_output]))"
    ]
@@ -276,27 +584,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# table_output = my_parser.to_list([Filter.MILESTONES, Filter.NOTES])\n",
-    "# print(\"\\n\".join([\"\\t\".join(row) for row in table_output]))\n"
+    "table_output = my_parser.to_list(exclude_markers=Filter.BOOK_HEADERS+Filter.TITLES+Filter.COMMENTS)\n",
+    "print(\"\\n\".join([\"\\t\".join(row) for row in table_output]))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "d7b6c4d0",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Book\tChapter\tVerse\tText\tType\n",
+      "EXO\t\t\t02EXOGNT92.SFM, Good News Translation, June 2003\tbook:id\n",
+      "EXO\t1\t1\tയാക്കോബിനോടുകൂടെ കുടുംബസഹിതം ഈജിപ്റ്റിൽ വന്ന യിസ്രായേൽമക്കളുടെ പേരുകൾ :\t\n",
+      "EXO\t1\t2\tരൂബേൻ, ശിമെയോൻ, ലേവി,\t\n",
+      "EXO\t1\t3\tയെഹൂദാ, യിസ്സാഖാർ, സെബൂലൂൻ, ബെന്യാമീൻ\t\n",
+      "EXO\t1\t4\tദാൻ, നഫ്താലി, ഗാദ്, ആശേർ.\t\n",
+      "EXO\t1\t12-83\tThey presented their offerings in the following order: Day Tribe Leader 1st Judah Nahshon son of Amminadab 2nd Issachar Nethanel son of Zuar 3rd Zebulun Eliab son of Helon\t\n",
+      "EXO\t1\t5\tയാക്കോബിന്റെ സന്താനപരമ്പരകൾ എല്ലാം കൂടി എഴുപതു പേർ ആയിരുന്നു; യോസേഫ് മുമ്പെ തന്നെ ഈജിപ്റ്റിൽ ആയിരുന്നു. gracious Lord and then a few words later gracious \t\n",
+      "EXO\t2\t1\tThis is a prayer of the prophet Habakkuk:\t\n",
+      "EXO\t2\t2\tO Lord, I have heard of what you have done, and I am filled with awe. Now do again in our times the great deeds you used to do. Be merciful, even when you are angry.\t\n",
+      "EXO\t2\t20\tAdam named his wife Eve, because she\n",
+      "was the mother of all human beings.\t\n",
+      "EXO\t2\t21\tAnd the Lord God made clothes out of animal skins for Adam and his wife,\n",
+      "and he clothed them. “Are you the king of the Jews?” \t\n"
+     ]
+    }
+   ],
+   "source": [
+    "table_output = my_parser.to_list(include_markers=Filter.BCV+Filter.TEXT)\n",
+    "print(\"\\n\".join([\"\\t\".join(row) for row in table_output]))"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "43049bb6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Book\tChapter\tVerse\tText\tType\n",
+      "EXO\t\t\t02EXOGNT92.SFM, Good News Translation, June 2003\tbook:id\n",
+      "EXO\t2\t20\t3.20:\tchar:fr\n",
+      "EXO\t2\t20\tAdam:\tchar:fk\n",
+      "EXO\t2\t20\tThis name in Hebrew means “all human beings.”\tchar:ft\n",
+      "EXO\t2\t20\t3.20:\tchar:fr\n",
+      "EXO\t2\t20\tEve:\tchar:fk\n",
+      "EXO\t2\t20\tThis name sounds similar to the Hebrew\n",
+      "word for “living,” which is rendered in this context as “human beings.”\tchar:ft\n"
+     ]
+    }
+   ],
    "source": [
-    "# table_output = my_parser.to_list([Filter.SCRIPTURE_TEXT])\n",
-    "# print(\"\\n\".join([\"\\t\".join(row) for row in table_output]))\n"
+    "table_output = my_parser.to_list(include_markers=Filter.NOTES)\n",
+    "print(\"\\n\".join([\"\\t\".join(row) for row in table_output]))\n"
    ]
   },
   {
@@ -433,9 +781,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ENV-for-usfmgrammar",
+   "display_name": "ENV-usfm-grammar-dev",
    "language": "python",
-   "name": "env-for-usfmgrammar"
+   "name": "env-usfm-grammar-dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -447,7 +795,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/py-usfm-parser/README.md
+++ b/py-usfm-parser/README.md
@@ -48,13 +48,25 @@ To convert to Dict
 
 ```
 output = my_parser.to_usj() # default all markers
-#output = my_parser.to_usj([Filter.SCRIPTURE_TEXT])
-#output = my_parser.to_usj([Filter.NOTES])
-#output = my_parser.to_usj([Filter.NOTES, Filter.ATTRIBUTES])
-#output = my_parser.to_usj([Filter.SCRIPTURE_TEXT, Filter.TITLES, Filter.PARAGRAPHS)
+
+# filters out specified markers from output
+# output = my_parser.to_usj(exclude_markers=['s1','h', 'toc1','toc2','mt'])
+
+# retains only specified contents from output
+# output = my_parser.to_usj(include_markers=['id', 'c', 'v']) 
+
+# use predefined marker groups instead of listing them one by one
+# output = my_parser.to_usj(include_markers=Filter.BCV+Filter.TEXT)
+
+# for a flattened JSON removing nesting brought in by paragraphs, lists, quotes, tables and character level markups
+# output = my_parser.to_usj(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS)
+
+# To NOT concatinate text extracted from different markers
+# output = my_parser.to_usj(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS, combine_texts=False) 
 
 print(output)
 ```
+To understand more about how `exclude_markers`, `include_markers`, `combine_texts`  and `Filter` works refer the section on [filtering on USJ](#filtering-on-usj)
 
 To save as json
 ```
@@ -78,11 +90,14 @@ print(table_output)
 
 ```
 usage: usfm-grammar [-h] [--format {json,table,syntax-tree,usx,markdown}]
-                    [--filter {book_headers,paragraphs,titles,scripture_text,notes,attributes,milestones,study_bible}]
+                    [--include_markers {book_headers,titles,...}]
+                    [--exclude_markers {book_headers,titles,...}]
                     [--csv_col_sep CSV_COL_SEP] [--csv_row_sep CSV_ROW_SEP]
+                    [--ignore_errors] [--combine_text]
                     infile
 
-Uses the tree-sitter-usfm grammar to parse and convert USFM to "+ "Syntax-tree, JSON, CSV, USX etc.
+Uses the tree-sitter-usfm grammar to parse and convert USFM to Syntax-tree,
+JSON, CSV, USX etc.
 
 positional arguments:
   infile                input usfm file
@@ -91,16 +106,70 @@ options:
   -h, --help            show this help message and exit
   --format {json,table,syntax-tree,usx,markdown}
                         output format
-  --filter {book_headers,paragraphs,titles,scripture_text,notes,attributes,milestones,study_bible}
-                        the type of contents to be included
+  --include_markers {book_headers,titles,comments,paragraphs,characters,notes,study_bible,bcv,text,ide,usfm,h,toc,toca,imt,is,ip,ipi,im,imi,ipq,imq,ipr,iq,ib,ili,iot,io,iex,imte,ie,mt,mte,cl,cd,ms,mr,s,sr,r,d,sp,sd,sts,rem,lit,restore,p,m,po,pr,cls,pmo,pm,pmc,pmr,pi,mi,nb,pc,ph,q,qr,qc,qa,qm,qd,lh,li,lf,lim,litl,tr,tc,th,tcr,thr,table,b,add,bk,dc,ior,iqt,k,litl,nd,ord,pn,png,qac,qs,qt,rq,sig,sls,tl,wj,em,bd,bdit,it,no,sc,sup,rb,pro,w,wh,wa,wg,lik,liv,jmp,f,fe,ef,efe,x,ex,fr,ft,fk,fq,fqa,fl,fw,fp,fv,fdc,xo,xop,xt,xta,xk,xq,xot,xnt,xdc,esb,cat,id,c,v,text-in-excluded-parent}
+                        the list of of contents to be included
+  --exclude_markers {book_headers,titles,comments,paragraphs,characters,notes,study_bible,bcv,text,ide,usfm,h,toc,toca,imt,is,ip,ipi,im,imi,ipq,imq,ipr,iq,ib,ili,iot,io,iex,imte,ie,mt,mte,cl,cd,ms,mr,s,sr,r,d,sp,sd,sts,rem,lit,restore,p,m,po,pr,cls,pmo,pm,pmc,pmr,pi,mi,nb,pc,ph,q,qr,qc,qa,qm,qd,lh,li,lf,lim,litl,tr,tc,th,tcr,thr,table,b,add,bk,dc,ior,iqt,k,litl,nd,ord,pn,png,qac,qs,qt,rq,sig,sls,tl,wj,em,bd,bdit,it,no,sc,sup,rb,pro,w,wh,wa,wg,lik,liv,jmp,f,fe,ef,efe,x,ex,fr,ft,fk,fq,fqa,fl,fw,fp,fv,fdc,xo,xop,xt,xta,xk,xq,xot,xnt,xdc,esb,cat,id,c,v,text-in-excluded-parent}
+                        the list of of contents to be included
   --csv_col_sep CSV_COL_SEP
-                        column separator or delimiter. Only useful with format=table.
+                        column separator or delimiter. Only useful with
+                        format=table.
   --csv_row_sep CSV_ROW_SEP
-                        row separator or delimiter. Only useful with format=table.
+                        row separator or delimiter. Only useful with
+                        format=table.
+  --ignore_errors       to get some output from successfully parsed portions
+  --combine_text        to be used along with exclude_markers or
+                        include_markers, to concatinate the consecutive text
+                        snippets, from different components, or not
 ```
 Example
 ```
 >>> python3 -m usfm_grammar sample.usfm --format usx
 
 >>> usfm-grammar sample.usfm --format usx
+
+>>> usfm-grammar sample.usfm --include_markers bcv --include_markers text --include_markers s
 ```
+
+### Filtering on USJ
+
+The filtering on USJ, the JSON output, is a feature incorporated to allow data extraction, markup cleaning etc. The arguments `exclude_markers` and `include_markers` in the methods `USFMParser.to_usj()` makes this possible. Also the  `USFMParser.to_list()`, can accept these inputs and perform similar operations. There is CLI versions also for these arguments to replicate the filtering feature there.
+
+- *include_markers*
+
+  Optional input parameter to `to_usj()` and `to_list` in python library and also in CLI when `format=json` or `format=table`. Defaults to `None`.When proivded, only those markers listed will be included in the output. `include_markers` is applied before applying `exclude_markers`. 
+
+- *exclude_markers*
+
+  Optional input parameter to `to_usj()` and `to_list` in python library and also in CLI when `format=json` or `format=table`. Defaults to `None`. When proivded, all markers except those listed will be included in the output.
+
+- *combine_texts*
+
+   Optional input parameter to `to_usj()` and `to_list` in python library and also in CLI when `format=json` or `format=table`. Defaults to `True`. After filtering out makers like paragraphs and characters, we are left with texts from within them, if 'text-in-excluded-parent' is also not excluded. These text snippets may come as separate components in the contents list. When this option is `True`, the consequetive text snippets will be concatinated together. The text concatination is done in a puctuation and space aware manner. If users need more control over the space handling or for any other reason, would prefer the texts snippets as different components in the output, this can be set to `False`.
+
+- *usfm_grammar.Filter*
+
+  This Class provides a set of enums that would be useful in providing in the `exclude_markers` and `include_markers` inputs rather than users listing out individual markers. The class has following options
+  ```
+    BOOK_HEADERS : identification and introduction markers
+    TITLES : section headings and associated markers
+    COMMENTS : comment markers like \rem
+    PARAGRAPHS : paragraph markers like \p, poetry markers, list table markers
+    CHARACTERS : all character level markups like \em, \w, \wj etc and their nested versions with +
+    NOTES : foot note, cross-reference and their content markers
+    STUDY_BIBLE : \esb and `cat
+    BCV : \id, \c and \v
+    TEXT : 'text-in-excluded-parent'
+    ```
+    To inspect which are the markers in each of these options, it could be just printed out, `print(Filter.TITLES)`. These could be used individually or concatinated to get the desired filtering of markers and data:
+    ```
+    output = my_parser.to_usj(include_markers=Filter.BCV)
+    output = my_parser.to_usj(include_markers=Filter.BCV+Filter.TEXT)
+    output = my_parser.to_usj(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS)
+    ``` 
+- Inner contents of excluded markers
+
+  For markers like `\p` `\q` etc, by excluding them, we only remove them from the heirachy and retain the inner contents like `\v`, text etc that would be coming inside it. But for certain other markers like `\f`, `\x`, `\esb`  etc, if they are excluded their inner contents are also excluded. Following is the set of all markers, who inner contents are discarded if they are mentioned in `exclude_markers` or not included in `include_markers`.
+  ```
+  BOOK_HEADERS, TITLES, COMMENTS, NOTES, STUDY_BIBLE
+  ```
+  :warning: Generally, it is recommended to NOT use both `exclude_markers` and `include_markers` together as it could lead to unexpected behavours and data loss. For instance if `include_makers` has `\fk` and `exclude_markers` has `\f`, the output will not contain `\fk` as all inner contents of `\f` will be discarded.

--- a/py-usfm-parser/src/usfm_grammar/__main__.py
+++ b/py-usfm-parser/src/usfm_grammar/__main__.py
@@ -7,32 +7,45 @@ import csv
 from lxml import etree
 
 from usfm_grammar import USFMParser, Filter, Format
+all_markers = []
+for member in Filter:
+    all_markers += member.value
+
 
 def main():
     '''handles the command line requests'''
     arg_parser = argparse.ArgumentParser(
-        description='Uses the tree-sitter-usfm grammar to parse and convert USFM to "+\
-        "Syntax-tree, JSON, CSV, USX etc.')
+        description='Uses the tree-sitter-usfm grammar to parse and convert USFM to '+\
+        'Syntax-tree, JSON, CSV, USX etc.')
     arg_parser.add_argument('infile', type=str, help='input usfm file')
     arg_parser.add_argument('--format', type=str, help='output format',
                             choices=[itm.value for itm in Format],
                             default=Format.JSON.value)
-    arg_parser.add_argument('--filter', type=str, help='the type of contents to be included',
-                            choices=[itm.name.lower() for itm in Filter],
-                            action="append")
+    arg_parser.add_argument('--include_markers', type=str, help='the list of of contents to be included',
+                            choices=[itm.name.lower() for itm in Filter]+all_markers,
+                            action='append')
+    arg_parser.add_argument('--exclude_markers', type=str, help='the list of of contents to be included',
+                            choices=[itm.name.lower() for itm in Filter]+all_markers,
+                            action='append')
     arg_parser.add_argument('--csv_col_sep', type=str,
-                            help="column separator or delimiter. Only useful with format=table.",
-                            default="\t")
+                            help='column separator or delimiter. Only useful with format=table.',
+                            default='\t')
     arg_parser.add_argument('--csv_row_sep', type=str,
-                            help="row separator or delimiter. Only useful with format=table.",
-                            default="\n")
+                            help='row separator or delimiter. Only useful with format=table.',
+                            default='\n')
     arg_parser.add_argument('--ignore_errors',
-                            help="to get some output from successfully parsed portions",
+                            help='to get some output from successfully parsed portions',
+                            action='store_true')
+    arg_parser.add_argument('--combine_text',
+                            help='to be used along with exclude_markers or include_markers, '+\
+                            'to concatinate the consecutive text snippets, '+\
+                            'from different components, or not',
                             action='store_true')
 
     infile = arg_parser.parse_args().infile
     output_format = arg_parser.parse_args().format
-    output_filter = arg_parser.parse_args().filter
+    exclude_markers = arg_parser.parse_args().exclude_markers
+    include_markers = arg_parser.parse_args().include_markers
 
     with open(infile, 'r', encoding='utf-8') as usfm_file:
         file_content = usfm_file.read()
@@ -44,19 +57,38 @@ def main():
         print(f"Errors present:\n\t{err_str}")
         sys.exit(1)
 
-    if output_filter is None:
-        updated_filt = None
+    filter_names =  [member.name for member in Filter]
+    if exclude_markers is None:
+        updated_exclude_markers = None
     else:
-        updated_filt = []
-        for itm in output_filter:
-            updated_filt.append(Filter[itm.upper()])
+        updated_exclude_markers = []
+        for itm in exclude_markers:
+            if itm.upper() in filter_names:
+                updated_exclude_markers += Filter[itm.upper()]
+            else:
+                updated_exclude_markers.append(itm.lower().replace("\\", ""))
+    if include_markers is None:
+        updated_include_markers = None
+    else:
+        updated_include_markers = []
+        for itm in include_markers:
+            if itm.upper() in filter_names:
+                updated_include_markers += Filter[itm.upper()]
+            else:
+                updated_include_markers.append(itm.lower().replace("\\", ""))
 
     match output_format:
         case Format.JSON:
-            dict_output = my_parser.to_usj(filters=updated_filt, ignore_errors=True)
+            dict_output = my_parser.to_usj(
+                exclude_markers=updated_exclude_markers,
+                include_markers=updated_include_markers,
+                ignore_errors=True)
             print(json.dumps(dict_output, indent=4, ensure_ascii=False))
         case Format.CSV:
-            table_output = my_parser.to_list(filters = updated_filt, ignore_errors=True)
+            table_output = my_parser.to_list(
+                exclude_markers=updated_exclude_markers,
+                include_markers=updated_include_markers,
+                ignore_errors=True)
             outfile = sys.stdout
             writer = csv.writer(outfile,
                 delimiter=arg_parser.parse_args().csv_col_sep,

--- a/py-usfm-parser/src/usfm_grammar/__main__.py
+++ b/py-usfm-parser/src/usfm_grammar/__main__.py
@@ -12,7 +12,7 @@ for member in Filter:
     all_markers += member.value
 
 
-def main():
+def main(): #pylint: disable=too-many-locals
     '''handles the command line requests'''
     arg_parser = argparse.ArgumentParser(
         description='Uses the tree-sitter-usfm grammar to parse and convert USFM to '+\
@@ -21,10 +21,12 @@ def main():
     arg_parser.add_argument('--format', type=str, help='output format',
                             choices=[itm.value for itm in Format],
                             default=Format.JSON.value)
-    arg_parser.add_argument('--include_markers', type=str, help='the list of of contents to be included',
+    arg_parser.add_argument('--include_markers', type=str,
+                            help='the list of of contents to be included',
                             choices=[itm.name.lower() for itm in Filter]+all_markers,
                             action='append')
-    arg_parser.add_argument('--exclude_markers', type=str, help='the list of of contents to be included',
+    arg_parser.add_argument('--exclude_markers', type=str,
+                            help='the list of of contents to be included',
                             choices=[itm.name.lower() for itm in Filter]+all_markers,
                             action='append')
     arg_parser.add_argument('--csv_col_sep', type=str,

--- a/py-usfm-parser/src/usfm_grammar/filters.py
+++ b/py-usfm-parser/src/usfm_grammar/filters.py
@@ -1,0 +1,122 @@
+'''Filtering implementations
+1. Removing unwanted markers from USJ, provided the list
+2. Inlcuding only the given list of markers in USJ
+'''
+import re
+
+MARKERS_WITH_DISCARDABLE_CONTENTS = ["ide", "usfm", "h", "toc", "toca", #identification
+                "imt", "is", "ip", "ipi", "im", "imi", "ipq", "imq", "ipr", "iq", "ib",
+                "ili", "iot", "io", "iex", "imte", "ie", # intro
+                "mt", "mte", "cl", "cd", "ms", "mr", "s", "sr", "r", "d", "sp", "sd", #titles
+                "sts", "rem", "lit", "restore", #comments
+                "f", "fe", "ef", "efe", "x", "ex", #NOTE_MARKERS
+                "fr", "ft", "fk", "fq", "fqa", "fl", "fw", "fp", "fv", "fdc", #footnote-content
+                "xo", "xop", "xt", "xta", "xk", "xq", "xot", "xnt", "xdc", #crossref-content
+                "jmp", "fig", "cat", "esb", "b",
+                ]
+
+trailing_num_pattern = re.compile(r'\d+$')
+punct_pattern_no_space_before = re.compile(r'^[,.\-—/;:!?@$%^)}\]>”»]')
+punct_pattern_no_space_after = re.compile(r'[\-—/`@^&({[<“«]$')
+# both lists exculde ', ", *, &, #, ~, |, +, _, =, \
+
+
+def combine_consequtive_text_contents(contents_list):
+    '''After filtering, if content endups with text items next to each other, concatinate them'''
+    text_combined_contents = []
+    text_contents = ''
+    for item in contents_list:
+        if isinstance(item, str):
+            if not (text_contents.endswith(" ")
+                        or item.startswith(" ")
+                        or text_contents==''
+                        or re.match(punct_pattern_no_space_before, item)
+                        or re.match(punct_pattern_no_space_after, text_contents)):
+                text_contents += " "
+            text_contents += item
+        else:
+            if text_contents != "":
+                text_combined_contents.append(text_contents)
+                text_contents = ""
+            text_combined_contents.append(item)
+    if text_contents != "":
+        text_combined_contents.append(text_contents)
+    return text_combined_contents
+
+def exclude_markers_in_usj(input_usj,
+    exclude_markers:list,
+    combine_texts=True,
+    excluded_parent=False):
+    """Removing unwanted markers from USJ, provided the list"""
+    if isinstance(input_usj, str):
+        if excluded_parent and 'text-in-excluded-parent' in exclude_markers:
+            return []
+        return [input_usj]
+    cleaned_kids = []
+    exclude_markers = [re.sub(trailing_num_pattern, '', item.split(':')[-1])
+                                                     for item in exclude_markers]
+    this_marker = re.sub(trailing_num_pattern,'', input_usj['type'].split(':')[-1])
+    this_marker_needed = True
+    excluded_parent=False # used to check if its text is needed or not, in the subsequent call
+    inner_content_needed = True
+    if this_marker in exclude_markers:
+        this_marker_needed =False
+        excluded_parent=True
+        if this_marker in MARKERS_WITH_DISCARDABLE_CONTENTS:
+            inner_content_needed = False
+    if (this_marker_needed or inner_content_needed) and "content" in input_usj:
+        for item in input_usj['content']:
+            cleaned_up_kid = exclude_markers_in_usj(
+                    item, exclude_markers, combine_texts, excluded_parent)
+            if isinstance(cleaned_up_kid, list):
+                cleaned_kids += cleaned_up_kid
+            else:
+                cleaned_kids.append(cleaned_up_kid)
+        if combine_texts:
+            cleaned_kids = combine_consequtive_text_contents(cleaned_kids)
+    if this_marker_needed:
+        cleaned_usj = input_usj.copy()
+        cleaned_usj['content'] = cleaned_kids
+        return cleaned_usj
+    if inner_content_needed:
+        return cleaned_kids
+    return []
+
+def include_markers_in_usj(input_usj,
+    include_markers:list, 
+    combine_texts=True,
+    excluded_parent=False):
+    """keeping only chosen markers in USJ, as per provided the list"""
+    if isinstance(input_usj, str):
+        if excluded_parent and 'text-in-excluded-parent' not in include_markers:
+            return []
+        return [input_usj]
+    cleaned_kids = []
+    include_markers = [re.sub(trailing_num_pattern,'', item.split(':')[-1])
+                                                for item in include_markers]
+    this_marker = re.sub(trailing_num_pattern,'', input_usj['type'].split(':')[-1])
+    this_marker_needed = True
+    excluded_parent = False # used to check if its text is needed or not in the subsequent call
+    inner_content_needed = True
+    if this_marker not in include_markers:
+        this_marker_needed =False
+        excluded_parent = True
+        if this_marker in MARKERS_WITH_DISCARDABLE_CONTENTS:
+            inner_content_needed = False
+    if (this_marker_needed or inner_content_needed) and "content" in input_usj:
+        for item in input_usj['content']:
+            cleaned_up_kid = include_markers_in_usj(
+                    item, include_markers, combine_texts, excluded_parent)
+            if isinstance(cleaned_up_kid, list):
+                cleaned_kids += cleaned_up_kid
+            else:
+                cleaned_kids.append(cleaned_up_kid)
+        if combine_texts:
+            cleaned_kids = combine_consequtive_text_contents(cleaned_kids)
+    if this_marker_needed:
+        cleaned_usj = input_usj.copy()
+        cleaned_usj['content'] = cleaned_kids
+        return cleaned_usj
+    if inner_content_needed:
+        return cleaned_kids
+    return []

--- a/py-usfm-parser/src/usfm_grammar/filters.py
+++ b/py-usfm-parser/src/usfm_grammar/filters.py
@@ -83,7 +83,7 @@ def exclude_markers_in_usj(input_usj,
     return []
 
 def include_markers_in_usj(input_usj,
-    include_markers:list, 
+    include_markers:list,
     combine_texts=True,
     excluded_parent=False):
     """keeping only chosen markers in USJ, as per provided the list"""

--- a/py-usfm-parser/src/usfm_grammar/list_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/list_generator.py
@@ -30,10 +30,14 @@ class ListGenerator:
             self.usj_to_list_c(obj)
         elif obj['type'] == "verse:v":
             self.usj_to_list_v(obj)
+        marker_type = obj['type']
+        if marker_type == "USJ":
+            # This would occur if the JSON got flatttened after removing paragraph markers
+            marker_type = ""
         if 'content' in obj:
             for item in obj['content']:
                 if isinstance(item, str):
                     self.list.append(
-                        [self.book, self.current_chapter, self.current_verse, item, obj['type']])
+                        [self.book, self.current_chapter, self.current_verse, item, marker_type])
                 else:
                     self.usj_to_list(item)

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -10,17 +10,33 @@ from lxml import etree
 from usfm_grammar.usx_generator import USXGenerator
 from usfm_grammar.usj_generator import USJGenerator
 from usfm_grammar.list_generator import ListGenerator
+from usfm_grammar.filters import exclude_markers_in_usj, include_markers_in_usj
 
-class Filter(str, Enum):
+class Filter(list, Enum):
     '''Defines the values of filter options'''
-    BOOK_HEADERS = "book-header-introduction-markers"
-    PARAGRAPHS = 'paragraphs-quotes-lists-tables'
-    TITLES = "sectionheadings"
-    SCRIPTURE_TEXT = 'verse-texts'
-    NOTES = "footnotes-and-crossrefs"
-    ATTRIBUTES = "character-level-attributes"
-    MILESTONES = "milestones-namespaces"
-    STUDY_BIBLE = "sidebars-extended-contents"
+    BOOK_HEADERS = ["ide", "usfm", "h", "toc", "toca", #identification
+                "imt", "is", "ip", "ipi", "im", "imi", "ipq", "imq", "ipr", "iq", "ib",
+                "ili", "iot", "io", "iex", "imte", "ie"] # intro
+    TITLES = ["mt", "mte", "cl", "cd", "ms", "mr", "s", "sr", "r", "d", "sp", "sd"]  # "headings"
+    COMMENTS = ["sts", "rem", "lit", "restore"]  # comment markers
+    PARAGRAPHS = ["p", "m", "po", "pr", "cls", "pmo", "pm", "pmc", #'paragraphs-quotes-lists-tables'
+                "pmr", "pi", "mi", "nb", "pc", "ph",
+                "q", "qr", "qc", "qa", "qm", "qd", 
+                "lh", "li", "lf", "lim", "litl", 
+                'tr', "tc", "th", "tcr", "thr", 'table']  
+    CHARACTERS = ["add", "bk", "dc", "ior", "iqt", "k", "litl", "nd", "ord", "pn",
+                "png", "qac", "qs", "qt", "rq", "sig", "sls", "tl", "wj", # Special-text
+                "em", "bd", "bdit", "it", "no", "sc", "sup", # character styling
+                 "rb", "pro", "w", "wh", "wa", "wg", #special-features
+                 "lik", "liv",] #structred list entries
+    NOTES = ["f", "fe", "ef", "efe", "x", "ex", # "footnotes-and-crossrefs"
+             "fr", "ft", "fk", "fq", "fqa", "fl", "fw", "fp", "fv", "fdc",
+             "xo", "xop", "xt", "xta", "xk", "xq", "xot", "xnt", "xdc"
+            ]
+    STUDY_BIBLE = ['esb', 'cat']  # "sidebars-extended-contents"
+    BCV = ['id','c','v']
+    TEXT = ['text-in-excluded-parent']
+    # INNER_CONTENT = ['content-in-excluded-parent']
 
 class Format(str, Enum):
     '''Defines the valid values for output formats'''
@@ -94,9 +110,13 @@ class USFMParser():
                 "\nUse ignore_errors=True, to generate output inspite of errors")
         return self.syntax_tree.sexp()
 
-    def to_usj(self, filters=None, ignore_errors=False): #pylint: disable=unused-argument
+    def to_usj(self,
+            exclude_markers=None,
+            include_markers=None,
+            ignore_errors=False,
+            combine_texts=True):
         '''convert the syntax_tree to the JSON format USJ.
-        Filtering of desired contents to be implemented'''
+        Filtering of desired contents using exclude markers option'''
         if not ignore_errors and self.errors:
             err_str = "\n\t".join([":".join(err) for err in self.errors])
             raise Exception("Errors present:"+\
@@ -116,9 +136,20 @@ class USFMParser():
                 err_str = "\n\t".join([":".join(err) for err in self.errors])
                 message += f"Could be due to an error in the USFM\n\t{err_str}"
             raise Exception(message)  from exe
-        return usj_generator.json_root_obj
+        output_usj = usj_generator.json_root_obj
+        if include_markers:
+            output_usj = include_markers_in_usj(output_usj,
+                                            include_markers+['USJ'], combine_texts)
+        if exclude_markers:
+            output_usj = exclude_markers_in_usj(output_usj,
+                                            exclude_markers, combine_texts)
+        return output_usj
 
-    def to_list(self, filters=None, ignore_errors=False): # pylint: disable=too-many-branches, too-many-locals
+    def to_list(self,
+            exclude_markers=None,
+            include_markers=None,
+            ignore_errors=False,
+            combine_texts=True):
         '''uses the toJSON function and converts JSON to CSV
         To be re-implemented to work with the flat JSON schema'''
         if not ignore_errors and self.errors:
@@ -127,10 +158,6 @@ class USFMParser():
                 f'\n\t{err_str}'+\
                 "\nUse ignore_errors=True, to generate output inspite of errors")
 
-        if filters is None:
-            filters = list(Filter)
-        if Filter.PARAGRAPHS in filters:
-            filters.remove(Filter.PARAGRAPHS)
         json_root_obj = {
                 "type": "USJ",
                 "version": "0.0.1-alpha.2",
@@ -140,6 +167,11 @@ class USFMParser():
             usj_generator = USJGenerator(USFM_LANGUAGE, self.usfm_bytes, json_root_obj)
             usj_generator.node_2_usj(self.syntax_tree, json_root_obj)
             usj_dict = usj_generator.json_root_obj
+            if include_markers:
+                usj_dict = include_markers_in_usj(usj_dict,
+                            include_markers+['USJ']+Filter.BCV, combine_texts)
+            if exclude_markers:
+                usj_dict = exclude_markers_in_usj(usj_dict, exclude_markers, combine_texts)
 
             list_generator = ListGenerator()
             list_generator.usj_to_list(usj_dict)

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -23,12 +23,14 @@ class Filter(list, Enum):
                 "pmr", "pi", "mi", "nb", "pc", "ph",
                 "q", "qr", "qc", "qa", "qm", "qd", 
                 "lh", "li", "lf", "lim", "litl", 
-                'tr', "tc", "th", "tcr", "thr", 'table']  
+                'tr', "tc", "th", "tcr", "thr", 'table',
+                "b"]
     CHARACTERS = ["add", "bk", "dc", "ior", "iqt", "k", "litl", "nd", "ord", "pn",
                 "png", "qac", "qs", "qt", "rq", "sig", "sls", "tl", "wj", # Special-text
                 "em", "bd", "bdit", "it", "no", "sc", "sup", # character styling
                  "rb", "pro", "w", "wh", "wa", "wg", #special-features
-                 "lik", "liv",] #structred list entries
+                 "lik", "liv", #structred list entries
+                 "jmp"]
     NOTES = ["f", "fe", "ef", "efe", "x", "ex", # "footnotes-and-crossrefs"
              "fr", "ft", "fk", "fq", "fqa", "fl", "fw", "fp", "fv", "fdc",
              "xo", "xop", "xt", "xta", "xk", "xq", "xot", "xnt", "xdc"

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -21,8 +21,8 @@ class Filter(list, Enum):
     COMMENTS = ["sts", "rem", "lit", "restore"]  # comment markers
     PARAGRAPHS = ["p", "m", "po", "pr", "cls", "pmo", "pm", "pmc", #'paragraphs-quotes-lists-tables'
                 "pmr", "pi", "mi", "nb", "pc", "ph",
-                "q", "qr", "qc", "qa", "qm", "qd", 
-                "lh", "li", "lf", "lim", "litl", 
+                "q", "qr", "qc", "qa", "qm", "qd",
+                "lh", "li", "lf", "lim", "litl",
                 'tr', "tc", "th", "tcr", "thr", 'table',
                 "b"]
     CHARACTERS = ["add", "bk", "dc", "ior", "iqt", "k", "litl", "nd", "ord", "pn",

--- a/py-usfm-parser/tests/__init__.py
+++ b/py-usfm-parser/tests/__init__.py
@@ -2,7 +2,7 @@
 from glob import glob
 import re
 from lxml import etree
-from src.usfm_grammar import USFMParser
+from src.usfm_grammar import USFMParser, Filter
 
 TEST_DIR = "../tests"
 

--- a/py-usfm-parser/tests/test_json_conversion.py
+++ b/py-usfm-parser/tests/test_json_conversion.py
@@ -4,7 +4,11 @@ import json
 from jsonschema import validate
 
 from tests import all_usfm_files, initialise_parser, doubtful_usfms, negative_tests,\
-    find_all_markers
+    find_all_markers, Filter
+
+all_valid_markers = []
+for member in Filter:
+    all_valid_markers += member.value
 
 test_files = all_usfm_files.copy()
 for file in doubtful_usfms+negative_tests:
@@ -20,11 +24,49 @@ def test_dict_converions_without_filter(file_path):
     usfm_dict = test_parser.to_usj()
     assert isinstance(usfm_dict, dict)
 
+@pytest.mark.parametrize('file_path', test_files)
+@pytest.mark.parametrize('exclude_markers', [
+                            ['v', 'c'],
+                            Filter.PARAGRAPHS,
+                            Filter.TITLES+Filter.BOOK_HEADERS
+                        ])
+@pytest.mark.timeout(30)
+def test_dict_converions_with_exclude_markers(file_path, exclude_markers):
+    '''Tests if input parses without errors'''
+    test_parser = initialise_parser(file_path)
+    assert not test_parser.errors, test_parser.errors
+    usj_dict = test_parser.to_usj(exclude_markers=exclude_markers)
+    assert isinstance(usj_dict, dict)
+    all_types_in_output = get_types(usj_dict)
+    for marker in exclude_markers:
+        assert marker not in all_types_in_output
+
+@pytest.mark.parametrize('file_path', test_files)
+@pytest.mark.parametrize('include_markers', [
+                            ['v', 'c'],
+                            Filter.PARAGRAPHS,
+                            Filter.TITLES+Filter.BOOK_HEADERS
+                        ])
+@pytest.mark.timeout(30)
+def test_dict_converions_with_include_markers(file_path, include_markers):
+    '''Tests if input parses without errors'''
+    test_parser = initialise_parser(file_path)
+    assert not test_parser.errors, test_parser.errors
+    usj_dict = test_parser.to_usj(include_markers=include_markers)
+    assert isinstance(usj_dict, dict)
+    all_types_in_output = get_types(usj_dict)
+    for marker in all_types_in_output:
+        if marker in all_valid_markers:
+            assert marker in include_markers
+
 def get_types(element):
     '''Recursive function to find all keys in the dict output'''
     types = []
     if isinstance(element, str):
         pass
+    elif element['type'].split(':')[0] == "ms":
+        types.append('milestone')
+        types.append(element['type'].split(':')[-1] )
     else:
         types += element['type'].split(':')
         if "altnumber" in element:

--- a/py-usfm-parser/tests/test_list_conversion.py
+++ b/py-usfm-parser/tests/test_list_conversion.py
@@ -1,5 +1,6 @@
 '''Test the to_dict or json conversion API'''
 import pytest
+import re
 
 from tests import all_usfm_files, initialise_parser, doubtful_usfms, negative_tests
 from src.usfm_grammar import Filter
@@ -15,5 +16,33 @@ def test_list_converions_without_filter(file_path):
     '''Tests if input parses without errors'''
     test_parser = initialise_parser(file_path)
     assert not test_parser.errors, test_parser.errors
-    usfm_list = test_parser.to_list([Filter.SCRIPTURE_TEXT])
+    usfm_list = test_parser.to_list()
     assert isinstance(usfm_list, list)
+
+@pytest.mark.parametrize('file_path', test_files)
+@pytest.mark.parametrize('exclude_markers', [['s', 'r']])
+@pytest.mark.timeout(30)
+def test_list_converions_with_exclude_markers(file_path, exclude_markers):
+    '''Tests if input parses without errors'''
+    test_parser = initialise_parser(file_path)
+    assert not test_parser.errors, test_parser.errors
+    usfm_list = test_parser.to_list(exclude_markers=exclude_markers)
+    assert isinstance(usfm_list, list)
+    for row in usfm_list[1:]:
+        assert row[4].split(':')[-1] not in exclude_markers
+
+trailing_num_pattern = re.compile(r'\d+$')
+@pytest.mark.parametrize('file_path', test_files)
+@pytest.mark.parametrize('include_markers', [['id', 'c', 'v']+Filter.TEXT+Filter.PARAGRAPHS])
+@pytest.mark.timeout(30)
+def test_list_converions_with_include_markers(file_path, include_markers):
+    '''Tests if input parses without errors'''
+    test_parser = initialise_parser(file_path)
+    assert not test_parser.errors, test_parser.errors
+    usfm_list = test_parser.to_list(include_markers=include_markers)
+    assert isinstance(usfm_list, list)
+    for row in usfm_list[1:]:
+        marker = row[4].split(':')[-1]
+        marker = re.sub(trailing_num_pattern, "", marker)
+        assert marker in include_markers
+            


### PR DESCRIPTION
- Implements #185 
- Details of implementation
 - include_markers option in to_usj()
 - exclude_markers option in to_usj()
 - include_markers option in to_list(), keeping BCV unless overridden by exclude
 - exclude_markers option in to_list()
 - combine_text=True option in to_list() and to_usj()
 - Filter enums for groups of markers
     - BOOK_HEADERS
     - TITLES
     - COMMENTS
     - PARAGRAPHS
     - CHARACTERS
     - NOTES
     - STUDY_BIBLE
     - BCV
     - TEXT
- CLI changes for the new feature
- Tests for the new feature
- Documentation of the new feature
  - API usage demo in python document
  - README.md, adding [a dedicated section](https://github.com/kavitharaju/usfm-grammar/tree/feature/185-filtering-on-usj/py-usfm-parser#filtering-on-usj) and [different usage examples](https://github.com/kavitharaju/usfm-grammar/tree/feature/185-filtering-on-usj/py-usfm-parser#by-importing-library-in-python-code)