### PR TITLE
Change ENUM to regex for bookcode in USJ schema definition

### DIFF
--- a/schemas/usj.js
+++ b/schemas/usj.js
@@ -1,5 +1,5 @@
 {
-  "$schema": "USJ-0.0.1-alpha.2",
+  "$schema": "USJ-0.0.1",
   "$id": "https://usfm-committee/usj.schema.json",
   "title": "Unified Scripture JSON",
   "description": "The JSON varient of USFM and USX data models",
@@ -35,7 +35,7 @@
         },
         "code": {
           "description": "The 3-letter book code in id element",
-          "enum": ["GEN", "EXO", "LEV", "NUM", "DEU", "JOS", "JDG", "RUT", "1SA", "2SA", "1KI", "2KI", "1CH", "2CH", "EZR", "NEH", "EST", "JOB", "PSA", "PRO", "ECC", "SNG", "ISA", "JER", "LAM", "EZK", "DAN", "HOS", "JOL", "AMO", "OBA", "JON", "MIC", "NAM", "HAB", "ZEP", "HAG", "ZEC", "MAL", "MAT", "MRK", "LUK", "JHN", "ACT", "ROM", "1CO", "2CO", "GAL", "EPH", "PHP", "COL", "1TH", "2TH", "1TI", "2TI", "TIT", "PHM", "HEB", "JAS", "1PE", "2PE", "1JN", "2JN", "3JN", "JUD", "REV", "TOB", "JDT", "ESG", "WIS", "SIR", "BAR", "LJE", "S3Y", "SUS", "BEL", "1MA", "2MA", "3MA", "4MA", "1ES", "2ES", "MAN", "PS2", "ODA", "PSS", "EZA", "5EZ", "6EZ", "DAG", "PS3", "2BA", "LBA", "JUB", "ENO", "1MQ", "2MQ", "3MQ", "REP", "4BA", "LAO", "FRT", "BAK", "OTH", "INT", "CNC", "GLO", "TDX", "NDX", "XXA", "XXB", "XXC", "XXD", "XXE", "XXF", "XXG"],
+          "pattern": "^[0-9A-Z]{3}$",
           "type": "string"
         },
         "altnumber": {


### PR DESCRIPTION
- Using same regex used in usfm-bible/tcdocs/grammar/usx.rng
- closes #225 