### PR TITLE
Version pin treesitter

### DIFF
--- a/py-usfm-parser/.bumpversion.cfg
+++ b/py-usfm-parser/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-beta.5
+current_version = 3.0.0-beta.6
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-(?P<release>\w+).(?P<num>\d+)

--- a/py-usfm-parser/dev-requirements.txt
+++ b/py-usfm-parser/dev-requirements.txt
@@ -1,7 +1,7 @@
-tree-sitter==0.20.1
+tree-sitter==0.21.3
 jupyterlab==3.4.4
 rnc2rng==2.6.6
-lxml==4.9.1
+lxml==5.2.2
 pylint==2.15.3
 pytest==7.1.3
 pytest-timeout==2.1.0

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.0-beta.5"
+version = "3.0.0-beta.6"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,2 +1,2 @@
-tree-sitter==0.20.1
-lxml==4.9.1
+tree-sitter==0.21.3
+lxml==5.2.2

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.0-beta.5",  # Required
+    version="3.0.0-beta.6",  # Required
     python_requires=">=3.10",
     install_requires=["tree-sitter==0.21.3", "lxml==5.2.2"],  # Optional
     package_data={  # Optional

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -9,7 +9,7 @@ setup(
     name="usfm-grammar",  # Required
     version="3.0.0-beta.5",  # Required
     python_requires=">=3.10",
-    install_requires=["tree-sitter", "lxml"],  # Optional
+    install_requires=["tree-sitter==0.21.3", "lxml==5.2.2"],  # Optional
     package_data={  # Optional
         "usfm_grammar": ["my-languages.so"],
     },

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -7,4 +7,4 @@ Filter = usfm_parser.Filter
 Format = usfm_parser.Format
 USFMParser = usfm_parser.USFMParser
 
-__version__ = "3.0.0-beta.5"
+__version__ = "3.0.0-beta.6"

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "scripts": {


### PR DESCRIPTION
- Fixes #238 
- Problem: Caused new installs with versions of tree-sitter 0.22.0 and above to break the code.
- Pins the version of dependencies in setup.py as well, as an immediate fix.
- Upgraded  versions to latest supported values.