### PR TITLE
Tests/python node web

### DIFF
--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -95,10 +95,10 @@ jobs:
           cd node-usfm-parser
           npm install .
           npm install ../tree-sitter-usfm3
-          node_modules/mocha/bin/mocha.js --timeout=4000 --grep "Include|Exclude|wild|Compare" --invert
+          node_modules/mocha/bin/mocha.js --timeout=40000 --grep "Include|Exclude|wild|Compare" --invert
 
   Run-Web-tests:
-    name: Run Node tests
+    name: Run Web tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -121,7 +121,7 @@ jobs:
           cp node_modules/web-tree-sitter/tree-sitter.wasm ./
           cp ../tree-sitter-usfm3/tree-sitter-usfm3.wasm ./tree-sitter-usfm.wasm
 
-          node_modules/mocha/bin/mocha.js --timeout=4000 --grep "Include|Exclude|wild|Compare" --invert
+          node_modules/mocha/bin/mocha.js --timeout=40000 --grep "Include|Exclude|wild|Compare" --invert
 
 
 

--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -119,7 +119,7 @@ jobs:
           npm install .
           cp node_modules/web-tree-sitter/tree-sitter.js src/web-tree-sitter/
           cp node_modules/web-tree-sitter/tree-sitter.wasm ./
-          cp ../tree-sitter-usfm3/tree-sitter-usfm.wasm ./
+          cp ../tree-sitter-usfm3/tree-sitter-usfm3.wasm ./tree-sitter-usfm.wasm
 
           node_modules/mocha/bin/mocha.js --timeout=4000 --grep "Include|Exclude|wild|Compare" --invert
 

--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -113,6 +113,8 @@ jobs:
           npm install --save nan
           npm install --save-dev tree-sitter-cli
           ./node_modules/.bin/tree-sitter generate
+          ./node_modules/.bin/tree-sitter build --wasm
+
       - name: Install dependencies
         run: |
           cd web-usfm-parser

--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -1,12 +1,12 @@
 name: Test-on-push
 
 # Run this workflow every time a new commit pushed to your repository
-on: 
-  push:
-  pull_request:
-    branches: 
-      - master
-      - version-3
+on: [push, pull_request ]
+  # push:
+  # pull_request:
+  #   branches: 
+  #     - master
+  #     - version-3
 
 jobs:
   # Set the job key. The key is displayed as the job name

--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -73,3 +73,55 @@ jobs:
         run:
           # pytest -k "not compare_usx_with_testsuite_samples and not testsuite_usx_with_rnc_grammar and not samples-from-wild and not 57-TIT.partial" -n auto
           python -m pytest -k "not compare_usx_with_testsuite_samples and not testsuite_usx_with_rnc_grammar and not generated_usx_with_rnc_grammar and not samples-from-wild" -n auto
+
+  Run-Node-tests:
+    name: Run Node tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup node and npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run tests
+        run: |
+          cd tree-sitter-usfm3
+          npm install --save nan
+          npm install --save-dev tree-sitter-cli
+          ./node_modules/.bin/tree-sitter generate
+      - name: Install dependencies
+        run: |
+          cd node-usfm-parser
+          npm install .
+          npm install ../tree-sitter-usfm3
+          node_modules/mocha/bin/mocha.js --timeout=4000 --grep "Include|Exclude|wild|Compare" --invert
+
+  Run-Web-tests:
+    name: Run Node tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup node and npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run tests
+        run: |
+          cd tree-sitter-usfm3
+          npm install --save nan
+          npm install --save-dev tree-sitter-cli
+          ./node_modules/.bin/tree-sitter generate
+      - name: Install dependencies
+        run: |
+          cd web-usfm-parser
+          npm install .
+          cp node_modules/web-tree-sitter/tree-sitter.js src/web-tree-sitter/
+          cp node_modules/web-tree-sitter/tree-sitter.wasm ./
+          cp ../tree-sitter-usfm3/tree-sitter-usfm.wasm ./
+
+          node_modules/mocha/bin/mocha.js --timeout=4000 --grep "Include|Exclude|wild|Compare" --invert
+
+
+

--- a/docs/Dev_notes.md
+++ b/docs/Dev_notes.md
@@ -57,7 +57,7 @@ cd tree-sitter-usfm3
 export PATH=$PATH:./node_modules/.bin
 tree-sitter generate
 tree-sitter build --wasm
-cp tree-sitter-usfm.wasm ../js-usfm-parser/
+cp tree-sitter-usfm.wasm ../web-usfm-parser/
 cd ..
 ```
 After npm install, copy the `tree-sitter.js` file from `node_modules/web-tree-sitter` to the `js-usfm-parser/src/web-tree-sitter` folder to include it in the bundle. Also copy the `tree-sitter.wasm` file to `js-usfm-parser/` to be included in the npm packaging.

--- a/docs/Dev_notes.md
+++ b/docs/Dev_notes.md
@@ -63,7 +63,7 @@ cd ..
 After npm install, copy the `tree-sitter.js` file from `node_modules/web-tree-sitter` to the `js-usfm-parser/src/web-tree-sitter` folder to include it in the bundle. Also copy the `tree-sitter.wasm` file to `js-usfm-parser/` to be included in the npm packaging.
 
 ```bash
-cd js-usfm-parser/
+cd web-usfm-parser/
 npm install .
 cp node_modules/web-tree-sitter/tree-sitter.js src/web-tree-sitter/
 cp node_modules/web-tree-sitter/tree-sitter.wasm ./

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -30,6 +30,7 @@
     "tree-sitter-usfm3": "file:../tree-sitter-usfm3"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "glob": "^11.0.0",
     "mocha": "^10.7.3",
     "parcel": "^2.12.0",

--- a/node-usfm-parser/src/filters.js
+++ b/node-usfm-parser/src/filters.js
@@ -1,3 +1,62 @@
+class Filter {
+  // Defines the values of filter options
+  static BOOK_HEADERS = [
+    "ide", "usfm", "h", "toc", "toca", // identification
+    "imt", "is", "ip", "ipi", "im", "imi", "ipq", "imq", "ipr", "iq", "ib",
+    "ili", "iot", "io", "iex", "imte", "ie" // intro
+  ];
+
+  static TITLES = [
+    "mt", "mte", "cl", "cd", "ms", "mr", "s", "sr", "r", "d", "sp", "sd" // headings
+  ];
+
+  static COMMENTS = ["sts", "rem", "lit", "restore"]; // comment markers
+
+  static PARAGRAPHS = [
+    "p", "m", "po", "pr", "cls", "pmo", "pm", "pmc", // paragraphs-quotes-lists-tables
+    "pmr", "pi", "mi", "nb", "pc", "ph", "q", "qr", "qc", "qa", "qm", "qd",
+    "lh", "li", "lf", "lim", "litl", 'tr', "tc", "th", "tcr", "thr", 'table', "b"
+  ];
+
+  static CHARACTERS = [
+    "add", "bk", "dc", "ior", "iqt", "k", "litl", "nd", "ord", "pn",
+    "png", "qac", "qs", "qt", "rq", "sig", "sls", "tl", "wj", // Special-text
+    "em", "bd", "bdit", "it", "no", "sc", "sup", // character styling
+    "rb", "pro", "w", "wh", "wa", "wg", // special-features
+    "lik", "liv", // structured list entries
+    "jmp"
+  ];
+
+  static NOTES = [
+    "f", "fe", "ef", "efe", "x", "ex", // footnotes-and-crossrefs
+    "fr", "ft", "fk", "fq", "fqa", "fl", "fw", "fp", "fv", "fdc",
+    "xo", "xop", "xt", "xta", "xk", "xq", "xot", "xnt", "xdc"
+  ];
+
+  static STUDY_BIBLE = ['esb', 'cat']; // sidebars-extended-contents
+
+  static BCV = ['id', 'c', 'v'];
+
+  static TEXT = ['text-in-excluded-parent'];
+
+  static keepOnly(inputUsj, includeMarkers, combineTexts=true) {
+    // let flattenedList = [].concat(...includeMarkers);
+    let cleanedMarkers = includeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
+    let filteredUSJ = includeMarkersInUsj(inputUsj, cleanedMarkers, combineTexts);
+
+    return filteredUSJ;
+  }
+
+  static remove(inputUsj, excludeMarkers, combineTexts=true) {
+    // let flattenedList = [].concat(...excludeMarkers);
+    let cleanedMarkers = excludeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
+    let filteredUSJ = excludeMarkersInUsj(inputUsj, cleanedMarkers, combineTexts);
+
+    return filteredUSJ;
+  }
+
+}
+
 const MARKERS_WITH_DISCARDABLE_CONTENTS = [
   "ide", "usfm", "h", "toc", "toca", "imt", "is", "ip", "ipi", "im", "imi",
   "ipq", "imq", "ipr", "iq", "ib", "ili", "iot", "io", "iex", "imte", "ie",
@@ -37,21 +96,25 @@ function combineConsecutiveTextContents(contentsList) {
 }
 
 function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excludedParent = false) {
+  let cleanedKids = [];
   if (typeof inputUsj === 'string') {
-    if (excludedParent && excludeMarkers.includes('text-in-excluded-parent')) {
+    if (excludedParent || excludeMarkers.includes('text-in-excluded-parent')) {
       return [];
     }
     return [inputUsj];
   }
 
-  let cleanedKids = [];
-  let cleanedMarkers = excludeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
-  let thisMarker = 'marker' in inputUsj ? inputUsj.marker.replace(trailingNumPattern, '') : '';
+  let thisMarker = '';
+  if ('marker' in inputUsj) {
+    thisMarker = inputUsj.marker.replace(trailingNumPattern, '');
+  } else if (inputUsj.type === 'ref') {
+    thisMarker = "ref";
+  } 
   let thisMarkerNeeded = true;
   let innerContentNeeded = true;
   excludedParent = false;
 
-  if (cleanedMarkers.includes(thisMarker)) {
+  if (excludeMarkers.includes(thisMarker)) {
     thisMarkerNeeded = false;
     excludedParent = true;
     if (MARKERS_WITH_DISCARDABLE_CONTENTS.includes(thisMarker)) {
@@ -74,21 +137,29 @@ function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excl
   }
 
   if (thisMarkerNeeded) {
-    let cleanedUsj = { ...inputUsj, content: cleanedKids };
-    return cleanedUsj;
+    inputUsj.content = cleanedKids;
+    return inputUsj;
   }
-  return innerContentNeeded ? cleanedKids : [];
+  return cleanedKids;
 }
 
 function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excludedParent = false) {
-  if (typeof inputUsj === 'string') {
-    return excludedParent ? [] : [inputUsj];
-  }
   let cleanedKids = [];
-  let cleanedMarkers = includeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
-  let thisMarker = 'marker' in inputUsj ? inputUsj.marker.replace(trailingNumPattern, '') : '';
-  let thisMarkerNeeded = cleanedMarkers.includes(thisMarker) || thisMarker === '';
-  let innerContentNeeded = thisMarkerNeeded || MARKERS_WITH_DISCARDABLE_CONTENTS.includes(thisMarker);
+  
+  if (typeof inputUsj === 'string') {
+    if (includeMarkers.includes(Filter.TEXT[0])) {
+      return [inputUsj]
+    } 
+    return []
+  }
+  let thisMarker = '';
+  if ('marker' in inputUsj) {
+    thisMarker = inputUsj.marker.replace(trailingNumPattern, '');
+  } else if (inputUsj.type === 'ref') {
+    thisMarker = "ref";
+  } 
+  let thisMarkerNeeded = includeMarkers.includes(thisMarker) || thisMarker === '';
+  let innerContentNeeded = thisMarkerNeeded || !MARKERS_WITH_DISCARDABLE_CONTENTS.includes(thisMarker);
 
   if (innerContentNeeded && "content" in inputUsj) {
     inputUsj.content.forEach(item => {
@@ -104,12 +175,28 @@ function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excl
     }
   }
 
-  if (thisMarkerNeeded) {
-    let cleanedUsj = { ...inputUsj, content: cleanedKids };
-    return cleanedUsj;
+  if (thisMarker === 'c') {
+    if (!includeMarkers.includes('ca'))
+      delete inputUsj.altnumber;
+    if (!includeMarkers.includes('cp'))
+      delete inputUsj.pubnumber;
+  } else if (thisMarker === 'v') {
+    if (!includeMarkers.includes('va'))
+      delete inputUsj.altnumber;
+    if (!includeMarkers.includes('vp'))
+      delete inputUsj.pubnumber;
   }
-  return innerContentNeeded ? cleanedKids : [];
+
+
+
+  if (thisMarkerNeeded) {
+    inputUsj.content = cleanedKids;
+    return inputUsj;
+  }
+  return cleanedKids;
 }
+ 
 
 exports.excludeMarkersInUsj = excludeMarkersInUsj;
 exports.includeMarkersInUsj = includeMarkersInUsj;
+exports.Filter = Filter;

--- a/node-usfm-parser/src/index.js
+++ b/node-usfm-parser/src/index.js
@@ -1,2 +1,5 @@
-const {USFMParser} = require("./usfmParser");
+const {USFMParser, Filter, Format } = require("./usfmParser");
+
 exports.USFMParser = USFMParser;
+exports.Filter = Filter;
+exports.Format = Format;

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -2,7 +2,7 @@ const Parser = require('tree-sitter');
 
 const {USFMGenerator} = require("./usfmGenerator");
 const {USJGenerator} = require("./usjGenerator"); 
-const { includeMarkersInUsj, excludeMarkersInUsj } = require("./filters.js");
+const { includeMarkersInUsj, excludeMarkersInUsj, Filter } = require("./filters.js");
 const USFM3 = require('tree-sitter-usfm3');
 const { Query } = Parser;
 
@@ -168,14 +168,28 @@ Only one of USFM, USJ or USX is supported in one object.`)
 		}
 
 		if (includeMarkers) {
-			outputUSJ = includeMarkersInUsj(outputUSJ, [...includeMarkers, 'USJ'], combineTexts);
+			outputUSJ = Filter.keepOnly(outputUSJ, [...includeMarkers, 'USJ'], combineTexts);
 		}
 		if (excludeMarkers) {
-			outputUSJ = excludeMarkersInUsj(outputUSJ, excludeMarkers, combineTexts);
+			outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
 		}
 
 		return outputUSJ;
 	}
 }
 
+
+
+class Format {
+  // Defines the valid values for input and output formats
+  static JSON = "usj";
+  static CSV = "table";
+  static ST = "syntax-tree";
+  static USX = "usx";
+  static MD = "markdown";
+  static USFM = "usfm";
+}
+
 exports.USFMParser = USFMParser;
+exports.Filter = Filter;
+exports.Format = Format;

--- a/node-usfm-parser/test/test_usj_conversion.js
+++ b/node-usfm-parser/test/test_usj_conversion.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const fs = require('node:fs');
+const Ajv = require('ajv');
 const {allUsfmFiles, initialiseParser, isValidUsfm, excludeUSJs, findAllMarkers} = require('./config');
 const {USFMParser} = require("../src/index");
 
@@ -101,11 +102,28 @@ describe("Ensure all markers are in USJ", () => {
 });
 
 
+describe("Validate USJ against schema", () => {
+  // Test generated USJ against USJ schema
+  const ajv = new Ajv();
+  const schemaStr = fs.readFileSync("../schemas/usj.js", 'utf8');
+  const schema = JSON.parse(schemaStr);
+  const validate = ajv.compile(schema);
 
+  allUsfmFiles.forEach(function(value) {
+    if (isValidUsfm[value]) {
+      it(`Validate USJ generated from ${value}`, (inputUsfmPath=value) => {
+        const testParser = initialiseParser(inputUsfmPath)
+        assert(testParser instanceof USFMParser)
+        const usj = testParser.toUSJ();
+        assert(usj instanceof Object);
 
+        assert(validate(usj));  
 
+      });
+    }
+  });
 
-
+});
 
 
 function stripTextValue(usjObj) {

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -104,7 +104,7 @@ class USFMParser():
 
         self.usfm_bytes = None
         self.syntax_tree = None
-        self.errors = None
+        self.errors = []
         self.warnings = []
 
         # Some basic sanity checks
@@ -125,6 +125,15 @@ class USFMParser():
             self.errors = [(f"At {err[0].start_point}", self.usfm_bytes[err[0].start_byte:
                                     err[0].end_byte].decode('utf-8'))
                                     for err in errors]
+        self.check_for_missing(self.syntax_tree)
+
+    def check_for_missing(self, node):
+        '''Identify and report the MISSING nodes also as errors'''
+        for child in node.children:
+            if child.is_missing :
+                self.errors.append((f"At {child.start_point}", f"Missing {child.type}"))
+            else:
+                self.check_for_missing(child) 
 
 
     def to_syntax_tree(self, ignore_errors=False):

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -133,7 +133,7 @@ class USFMParser():
             if child.is_missing :
                 self.errors.append((f"At {child.start_point}", f"Missing {child.type}"))
             else:
-                self.check_for_missing(child) 
+                self.check_for_missing(child)
 
 
     def to_syntax_tree(self, ignore_errors=False):

--- a/py-usfm-parser/tests/__init__.py
+++ b/py-usfm-parser/tests/__init__.py
@@ -94,7 +94,7 @@ pass_fail_override_list = {
     f"{TEST_DIR}/paratextTests/MarkersMissingSpace/origin.usfm": "fail",
     f"{TEST_DIR}/paratextTests/NestingInCrossReferences/origin.usfm": "fail",
     f"{TEST_DIR}/special-cases/empty-para/origin.usfm": "fail",
-    f"{TEST_DIR}/special-cases/sp/origin.usfm": "fail",
+    # f"{TEST_DIR}/special-cases/sp/origin.usfm": "fail",
     f"{TEST_DIR}/specExamples/extended/sidebars/origin.usfm":"fail",
 
     # No. of columns in table not validated by usfm-grammar
@@ -127,6 +127,18 @@ pass_fail_override_list = {
     f"{TEST_DIR}/usfmjsTests/luk_quotes/origin.usfm": "fail",
     f"{TEST_DIR}/biblica/BlankLinesWithFigures/origin.usfm": "fail", #\fig used without \p, only \b
 
+    # no space after \s5
+    f"{TEST_DIR}/usfmjsTests/usfmBodyTestD/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/usfm-body-testF/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/psa_quotes/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/pro_footnote/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/pro_quotes/origin.usfm": "fail",
+    f"{TEST_DIR}/samples-from-wild/doo43-1/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/gn_headers/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/isa_inline_quotes/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/job_footnote/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/mat-4-6.whitespace/origin.usfm": "fail",
+    f"{TEST_DIR}/usfmjsTests/out_of_sequence_chapters/origin.usfm": "fail",
     
     f"{TEST_DIR}/biblica/PublishingVersesWithFormatting/origin.usfm": "fail", # \c without number
 
@@ -143,6 +155,7 @@ pass_fail_override_list = {
 
     f"{TEST_DIR}/advanced/periph/origin.usfm": "fail", # Peripharals not implemented
     f"{TEST_DIR}/advanced/nesting1/origin.usfm": "fail", # We dont support char within char w/o +, yet
+    f"{TEST_DIR}/samples-from-wild/doo43-4/origin.usfm": "fail", # ior surronded by a () leaves a stray ) at the end.
 }
 
 negative_tests = []

--- a/py-usfm-parser/tests/test_json_conversion.py
+++ b/py-usfm-parser/tests/test_json_conversion.py
@@ -165,7 +165,7 @@ def strip_default_attrib_value(usj_dict):
                 if item['type'] == "char" and item['marker'] == "w":
                     if "lemma" in item:
                         item['lemma'] = item['lemma'].strip()
-            strip_default_attrib_value(item)
+                strip_default_attrib_value(item)
 
 
 @pytest.mark.parametrize('file_path', test_files)

--- a/schemas/usj.js
+++ b/schemas/usj.js
@@ -1,6 +1,6 @@
 {
-  "$schema": "USJ-0.0.1",
-  "$id": "https://usfm-committee/usj.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/usfm-bible/tcdocs/blob/main/grammar/usj.js",
   "title": "Unified Scripture JSON",
   "description": "The JSON varient of USFM and USX data models",
   "type": "object",

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -38,12 +38,13 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "ajv": "^8.17.1",
+    "glob": "^11.0.0",
+    "mocha": "^10.7.3",
     "parcel": "latest",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "web-tree-sitter": "^0.22.6",
-    "glob": "^11.0.0",
-    "mocha": "^10.7.3",
     "xml2js": "^0.6.2"
   }
 }

--- a/web-usfm-parser/src/filters.js
+++ b/web-usfm-parser/src/filters.js
@@ -1,3 +1,62 @@
+class Filter {
+  // Defines the values of filter options
+  static BOOK_HEADERS = [
+    "ide", "usfm", "h", "toc", "toca", // identification
+    "imt", "is", "ip", "ipi", "im", "imi", "ipq", "imq", "ipr", "iq", "ib",
+    "ili", "iot", "io", "iex", "imte", "ie" // intro
+  ];
+
+  static TITLES = [
+    "mt", "mte", "cl", "cd", "ms", "mr", "s", "sr", "r", "d", "sp", "sd" // headings
+  ];
+
+  static COMMENTS = ["sts", "rem", "lit", "restore"]; // comment markers
+
+  static PARAGRAPHS = [
+    "p", "m", "po", "pr", "cls", "pmo", "pm", "pmc", // paragraphs-quotes-lists-tables
+    "pmr", "pi", "mi", "nb", "pc", "ph", "q", "qr", "qc", "qa", "qm", "qd",
+    "lh", "li", "lf", "lim", "litl", 'tr', "tc", "th", "tcr", "thr", 'table', "b"
+  ];
+
+  static CHARACTERS = [
+    "add", "bk", "dc", "ior", "iqt", "k", "litl", "nd", "ord", "pn",
+    "png", "qac", "qs", "qt", "rq", "sig", "sls", "tl", "wj", // Special-text
+    "em", "bd", "bdit", "it", "no", "sc", "sup", // character styling
+    "rb", "pro", "w", "wh", "wa", "wg", // special-features
+    "lik", "liv", // structured list entries
+    "jmp"
+  ];
+
+  static NOTES = [
+    "f", "fe", "ef", "efe", "x", "ex", // footnotes-and-crossrefs
+    "fr", "ft", "fk", "fq", "fqa", "fl", "fw", "fp", "fv", "fdc",
+    "xo", "xop", "xt", "xta", "xk", "xq", "xot", "xnt", "xdc"
+  ];
+
+  static STUDY_BIBLE = ['esb', 'cat']; // sidebars-extended-contents
+
+  static BCV = ['id', 'c', 'v'];
+
+  static TEXT = ['text-in-excluded-parent'];
+
+  static keepOnly(inputUsj, includeMarkers, combineTexts=true) {
+    // let flattenedList = [].concat(...includeMarkers);
+    let cleanedMarkers = includeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
+    let filteredUSJ = includeMarkersInUsj(inputUsj, cleanedMarkers, combineTexts);
+
+    return filteredUSJ;
+  }
+
+  static remove(inputUsj, excludeMarkers, combineTexts=true) {
+    // let flattenedList = [].concat(...excludeMarkers);
+    let cleanedMarkers = excludeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
+    let filteredUSJ = excludeMarkersInUsj(inputUsj, cleanedMarkers, combineTexts);
+
+    return filteredUSJ;
+  }
+
+}
+
 const MARKERS_WITH_DISCARDABLE_CONTENTS = [
   "ide", "usfm", "h", "toc", "toca", "imt", "is", "ip", "ipi", "im", "imi",
   "ipq", "imq", "ipr", "iq", "ib", "ili", "iot", "io", "iex", "imte", "ie",
@@ -37,21 +96,25 @@ function combineConsecutiveTextContents(contentsList) {
 }
 
 function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excludedParent = false) {
+  let cleanedKids = [];
   if (typeof inputUsj === 'string') {
-    if (excludedParent && excludeMarkers.includes('text-in-excluded-parent')) {
+    if (excludedParent || excludeMarkers.includes('text-in-excluded-parent')) {
       return [];
     }
     return [inputUsj];
   }
 
-  let cleanedKids = [];
-  let cleanedMarkers = excludeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
-  let thisMarker = 'marker' in inputUsj ? inputUsj.marker.replace(trailingNumPattern, '') : '';
+  let thisMarker = '';
+  if ('marker' in inputUsj) {
+    thisMarker = inputUsj.marker.replace(trailingNumPattern, '');
+  } else if (inputUsj.type === 'ref') {
+    thisMarker = "ref";
+  } 
   let thisMarkerNeeded = true;
   let innerContentNeeded = true;
   excludedParent = false;
 
-  if (cleanedMarkers.includes(thisMarker)) {
+  if (excludeMarkers.includes(thisMarker)) {
     thisMarkerNeeded = false;
     excludedParent = true;
     if (MARKERS_WITH_DISCARDABLE_CONTENTS.includes(thisMarker)) {
@@ -74,21 +137,29 @@ function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excl
   }
 
   if (thisMarkerNeeded) {
-    let cleanedUsj = { ...inputUsj, content: cleanedKids };
-    return cleanedUsj;
+    inputUsj.content = cleanedKids;
+    return inputUsj;
   }
-  return innerContentNeeded ? cleanedKids : [];
+  return cleanedKids;
 }
 
 function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excludedParent = false) {
-  if (typeof inputUsj === 'string') {
-    return excludedParent ? [] : [inputUsj];
-  }
   let cleanedKids = [];
-  let cleanedMarkers = includeMarkers.map(marker => marker.replace(trailingNumPattern, ''));
-  let thisMarker = 'marker' in inputUsj ? inputUsj.marker.replace(trailingNumPattern, '') : '';
-  let thisMarkerNeeded = cleanedMarkers.includes(thisMarker) || thisMarker === '';
-  let innerContentNeeded = thisMarkerNeeded || MARKERS_WITH_DISCARDABLE_CONTENTS.includes(thisMarker);
+  
+  if (typeof inputUsj === 'string') {
+    if (includeMarkers.includes(Filter.TEXT[0])) {
+      return [inputUsj]
+    } 
+    return []
+  }
+  let thisMarker = '';
+  if ('marker' in inputUsj) {
+    thisMarker = inputUsj.marker.replace(trailingNumPattern, '');
+  } else if (inputUsj.type === 'ref') {
+    thisMarker = "ref";
+  } 
+  let thisMarkerNeeded = includeMarkers.includes(thisMarker) || thisMarker === '';
+  let innerContentNeeded = thisMarkerNeeded || !MARKERS_WITH_DISCARDABLE_CONTENTS.includes(thisMarker);
 
   if (innerContentNeeded && "content" in inputUsj) {
     inputUsj.content.forEach(item => {
@@ -104,11 +175,25 @@ function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excl
     }
   }
 
-  if (thisMarkerNeeded) {
-    let cleanedUsj = { ...inputUsj, content: cleanedKids };
-    return cleanedUsj;
+  if (thisMarker === 'c') {
+    if (!includeMarkers.includes('ca'))
+      delete inputUsj.altnumber;
+    if (!includeMarkers.includes('cp'))
+      delete inputUsj.pubnumber;
+  } else if (thisMarker === 'v') {
+    if (!includeMarkers.includes('va'))
+      delete inputUsj.altnumber;
+    if (!includeMarkers.includes('vp'))
+      delete inputUsj.pubnumber;
   }
-  return innerContentNeeded ? cleanedKids : [];
-}
 
-export { excludeMarkersInUsj, includeMarkersInUsj };
+
+
+  if (thisMarkerNeeded) {
+    inputUsj.content = cleanedKids;
+    return inputUsj;
+  }
+  return cleanedKids;
+}
+ 
+export { Filter };

--- a/web-usfm-parser/src/index.js
+++ b/web-usfm-parser/src/index.js
@@ -1,3 +1,3 @@
-import USFMParser from "./usfmParser.js";
+import {USFMParser, Filter} from "./usfmParser.js";
 
-export { USFMParser };
+export { USFMParser, Filter };

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -2,7 +2,7 @@ import Parser from './web-tree-sitter/tree-sitter.js';
 
 import USFMGenerator from "./usfmGenerator.js";
 import USJGenerator from "./usjGenerator.js";
-import { includeMarkersInUsj, excludeMarkersInUsj } from "./filters.js";
+import { Filter } from "./filters.js";
 
 
 class USFMParser {
@@ -183,14 +183,14 @@ Only one of USFM, USJ or USX is supported in one object.`)
 		}
 
 		if (includeMarkers) {
-			outputUSJ = includeMarkersInUsj(outputUSJ, [...includeMarkers, 'USJ'], combineTexts);
+			outputUSJ = Filter.keepOnly(outputUSJ, [...includeMarkers, 'USJ'], combineTexts);
 		}
 		if (excludeMarkers) {
-			outputUSJ = excludeMarkersInUsj(outputUSJ, excludeMarkers, combineTexts);
+			outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
 		}
 
 		return outputUSJ;
 	}
 }
 
-export default USFMParser;
+export {USFMParser, Filter};

--- a/web-usfm-parser/test/config.js
+++ b/web-usfm-parser/test/config.js
@@ -104,10 +104,11 @@ let excludeUSJs = [
     `${TEST_DIR}/specExamples/character/origin.json`,// lit element treated as a body paragraph enclosing a verse! Issue from USX   
 
     ]
+    
+await USFMParser.init("./tree-sitter-usfm.wasm", "./tree-sitter.wasm");
 
 const initialiseParser = async function (inputUsfmPath){
     `Open and parse the given file`
-    await USFMParser.init("./tree-sitter-usfm.wasm", "./tree-sitter.wasm");
     try {
       const data = fs.readFileSync(inputUsfmPath, 'utf8');
       let testParser = new USFMParser(data);


### PR DESCRIPTION
- Part of #152 
- Fix issues in Exclude and Include Markers options in node and web. Write tests for them.
- Copy the same list of overridden tests from js modules to python
- Add more tests in node and web as present in python
    - Checking for all marker nodes in generated USJs
    - Validating generated USJ with the USJ JSON schema definition
    - Now there are **2122** test cases that all pass in both node and web
- Add gitaction jobs to run some of the node and web tests upon push and PR 
