### PR TITLE
Bump version: 3.0.0-beta.10 → 3.0.0-beta.11

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-beta.10
+current_version = 3.0.0-beta.11
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-(?P<release>\w+).(?P<num>\d+)

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["usfm", "parser", "grammar", "tree-sitter"]
 dependencies = [
     'tree-sitter==0.22.3; python_version >= "3.9"',
-    'tree-sitter-usfm3==3.0.0-beta.10; python_version >="3.8"',
+    'tree-sitter-usfm3==3.0.0-beta.11; python_version >="3.8"',
     'lxml==5.2.2; python_version >= "3.5"'
 ]
 requires-python = ">=3.10"

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,3 +1,3 @@
 tree-sitter==0.22.3
-tree-sitter-usfm3==3.0.0-beta.10
+tree-sitter-usfm3==3.0.0-beta.11
 lxml==5.2.2

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.0-beta.10",  # Required
+    version="3.0.0-beta.11",  # Required
     python_requires=">=3.10",
     # install_requires=["tree-sitter==0.22.3",
                         # "tree-sitter-usfm3==3.0.0-beta.7",  

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -9,4 +9,4 @@ USFMParser = usfm_parser.USFMParser
 
 Validator = validator.Validator
 
-__version__ = "3.0.0-beta.10"
+__version__ = "3.0.0-beta.11"

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0-beta.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-usfm3",
-      "version": "3.0.0-beta.10",
+      "version": "3.0.0-beta.11",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0-beta.11",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/tree-sitter-usfm3/pyproject.toml
+++ b/tree-sitter-usfm3/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-usfm3"
 description = "Usfm3 grammar for tree-sitter"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 keywords = ["incremental", "parsing", "tree-sitter", "usfm3"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
For packages:
- [JS tree-siiter-usfm3](https://www.npmjs.com/package/tree-sitter-usfm3) :heavy_check_mark: 
- [Python tree-sitter-usfm3](https://pypi.org/project/tree-sitter-usfm3/) :heavy_check_mark: 
- [Python usfm-grammar](https://pypi.org/project/usfm-grammar/) :heavy_check_mark: 
- [JS usfm-grammar](https://www.npmjs.com/package/usfm-grammar) :x: 
- [JS usfm-grammar-web](https://www.npmjs.com/package/usfm-grammar-web?activeTab=readme) :x: 

For the JS packages we need to do a few more alphas manually, and also automate the publication process.