### PR TITLE
Biblenlp format

### DIFF
--- a/node-usfm-parser/README.md
+++ b/node-usfm-parser/README.md
@@ -140,8 +140,8 @@ The filtering on USJ, the JSON output, is a feature incorporated to allow data e
     To inspect which are the markers in each of these options, it could be just printed out, `print(Filter.TITLES)`. These could be used individually or concatinated to get the desired filtering of markers and data:
     ```javascript
     output = usfmParser.toUSJ(null, include_markers=Filter.BCV)
-    output = usfmParser.toUSJ(null, include_markers=Filter.BCV+Filter.TEXT)
-    output = usfmParser.toUSJ(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS)
+    output = usfmParser.toUSJ(null, include_markers=[...Filter.BCV, ...Filter.TEXT])
+    output = usfmParser.toUSJ(exclude_markers=[...Filter.PARAGRAPHS, ...Filter.CHARACTERS])
     ``` 
 - Inner contents of excluded markers
 

--- a/node-usfm-parser/README.md
+++ b/node-usfm-parser/README.md
@@ -61,6 +61,36 @@ const usfmGen = usfmParser2.usfm;
 console.log(usfmGen);
 ```
 
+### BibleNLP format
+Bible NLP format consists of two `txt` files: the first, with verse texts, one per line and the second, with corresponding references. The API generates a JSON with two fields, `text` and `vref`, each containing an array of strings.
+
+```javascript
+
+const output = usfmParser.toBibleNlpFormat() 
+//const output = my_parser.toBibleNlpFormat(true) //ignore_errors
+
+const textLines = output.text.join('\n');
+fs.writeFileSync('bibleNLP.txt', textLines, { encoding: 'utf-8' });
+
+const refLines = output.vref.join('\n');
+fs.writeFileSync('vref.txt', refLines, { encoding: 'utf-8' });
+```
+
+### Table/List format
+
+```javascript
+const listOutput = usfmParser.toList();
+/* const listOutput = usfmParser.toList(
+                      Filter.NOTES,  //exclude
+                      ["id", "c", "v"] //include
+                      true,  //ignore errors
+                      true  //combine texts
+                      )*/
+const tableOutput = listOutput.map(row => row.join('\t')).join('\n');
+console.log(tableOutput);
+```
+
+
 ### Autofix and Validation
 Experimental Validation and Autofix feature for USFM:
 ```javascript

--- a/node-usfm-parser/src/index.js
+++ b/node-usfm-parser/src/index.js
@@ -1,7 +1,7 @@
-const {USFMParser, Filter, Format } = require("./usfmParser");
+const {USFMParser, Filter } = require("./usfmParser");
 const {Validator} = require("./validator");
 
 exports.USFMParser = USFMParser;
 exports.Filter = Filter;
-exports.Format = Format;
+// exports.Format = Format;
 exports.Validator = Validator;

--- a/node-usfm-parser/src/listGenerator.js
+++ b/node-usfm-parser/src/listGenerator.js
@@ -6,6 +6,9 @@ class ListGenerator {
         this.currentChapter = "";
         this.currentVerse = "";
         this.list = [["Book", "Chapter", "Verse", "Text", "Type", "Marker"]];
+        this.bibleNlpFormat = { "text" : [], "vref":[] }
+        this.prevChapter = ""
+        this.prevVerse = ""
     }
 
     usjToListId(obj) {
@@ -51,6 +54,36 @@ class ListGenerator {
             }
         }
     }
+
+    usjToBibleNlpFormat(obj) {
+        // Traverse the USJ object and build a dictionary for Bible NLP format
+        if (obj.type === "book") {
+            this.usjToListId(obj);
+        } else if (obj.type === "chapter") {
+            this.usjToListC(obj);
+        } else if (obj.type === "verse") {
+            this.usjToListV(obj);
+        } else if ( obj.content) {
+            for (const item of obj.content) {
+                if (typeof item === "string") {
+                    if (this.currentChapter === this.prevChapter &&
+                        this.currentVerse === this.prevVerse) {
+                        this.bibleNlpFormat.text[this.bibleNlpFormat.text.length - 1] +=
+                            " " + item.replace(/[\n\r]/g, " ").trim();
+                    } else {
+                        const vref = `${this.book} ${this.currentChapter}:${this.currentVerse}`;
+                        this.bibleNlpFormat.text.push(item.replace(/[\n\r]/g, " ").trim());
+                        this.bibleNlpFormat.vref.push(vref);
+                        this.prevChapter = this.currentChapter;
+                        this.prevVerse = this.currentVerse;
+                    }
+                } else {
+                    this.usjToBibleNlpFormat(item);
+                }
+            }
+        }
+    }
+
 }
 
 exports.ListGenerator = ListGenerator;

--- a/node-usfm-parser/src/usfmGenerator.js
+++ b/node-usfm-parser/src/usfmGenerator.js
@@ -60,7 +60,9 @@ class USFMGenerator {
     let attributes = [];
     Object.keys(usjObj).forEach((key) => {
       if (!NON_ATTRIB_USJ_KEYS.includes(key)) {
-        attributes.push(`${key}="${usjObj[key]}"`);
+        let lhs = key;
+        if (key === "file") { lhs = "src" }
+        attributes.push(`${lhs}="${usjObj[key]}"`);
       }
     });
 
@@ -74,6 +76,18 @@ class USFMGenerator {
         this.usfmString += "+";
       }
       this.usfmString += `${usjObj.marker}* `;
+    }
+    if (usjObj.type === "ms") {
+        if ("sid" in usjObj) {
+            if (attributes.length == 0 ) {
+                this.usfmString += '|';
+            }
+            this.usfmString += `sid="${usjObj.sid}" `;
+        }
+        this.usfmString = this.usfmString.trim() + "\\*";
+    }
+    if (usjObj.type === "sidebar" ) {
+        this.usfmString += "\\esbe";
     }
     if (
       !NO_NEWLINE_USJ_TYPES.includes(usjObj.type) &&

--- a/node-usfm-parser/src/usfmGenerator.js
+++ b/node-usfm-parser/src/usfmGenerator.js
@@ -1,6 +1,5 @@
 const { NO_USFM_USJ_TYPES, CLOSING_USJ_TYPES, NON_ATTRIB_USJ_KEYS, NO_NEWLINE_USJ_TYPES } = require("./utils/types");
 const { NON_ATTRIB_USX_KEYS, NO_NEWLINE_USX_TYPES } = require("./utils/types");
-const { DOMParser } = require('xmldom');
 
 class USFMGenerator {
   constructor() {

--- a/node-usfm-parser/src/usfmGenerator.js
+++ b/node-usfm-parser/src/usfmGenerator.js
@@ -8,6 +8,13 @@ class USFMGenerator {
   }
 
   usjToUsfm(usjObj, nested = false) {
+    if (usjObj.type === 'optbreak') {
+        if (this.usfmString !== '' && !['\n', '\r', ' ', '\t'].includes(this.usfmString.slice(-1))) {
+                this.usfmString += ' ';
+            }
+        this.usfmString += '// ';
+        return
+    }
     if (usjObj.type === "ref") {
         usjObj.marker = "ref";
     }

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -240,6 +240,32 @@ Only one of USFM, USJ or USX is supported in one object.`)
 
 	}
 
+	toBibleNlpFormat(ignoreErrors = false) {
+	    /* Uses the toUSJ function with only BVC and text.
+	       Then the JSOn is converted to list of verse texts and vrefs*/
+
+	    if (!ignoreErrors && this.errors.length > 0) {
+			let errorString = this.errors.join("\n\t");
+	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
+	    }
+
+	    try {
+	        const usjDict = this.toUSJ(null, [...Filter.BCV, ...Filter.TEXT], ignoreErrors, true);
+	        const listGenerator = new ListGenerator();
+	        listGenerator.usjToBibleNlpFormat(usjDict);
+	    	return listGenerator.bibleNlpFormat;
+
+	    } catch (exe) {
+	        let message = "Unable to do the conversion. ";
+	        if (this.errors.length > 0) {
+				let errorString = this.errors.join("\n\t");
+	            message += `Could be due to an error in the USFM\n\t${errorString}`;
+	        }
+	        throw new Error(message, { cause: exe });
+	    }
+
+	}
+
 	toUSX(ignoreErrors = false) {
 	    /* Convert the syntax_tree to the XML format (USX) */
 

--- a/node-usfm-parser/test/test_list_conversion.js
+++ b/node-usfm-parser/test/test_list_conversion.js
@@ -50,7 +50,7 @@ describe("Test Exclude Marker option in List conversion", () => {
 describe("Test include Marker option in List conversion", () => {
     // Test include Maker option by checking markers in the List
     const includeTests = [
-            ['id', 'c', 'v']+Filter.TEXT+Filter.PARAGRAPHS
+            ['id', 'c', 'v', ...Filter.TEXT, ...Filter.PARAGRAPHS]
             ]
     includeTests.forEach(function(inList) {
         allUsfmFiles.forEach(function(value) {
@@ -68,4 +68,45 @@ describe("Test include Marker option in List conversion", () => {
           }
         })
     })
+});
+
+describe("Test USFM to BibleNLP format conversion", () => {
+  allUsfmFiles.forEach(function(value) {
+    if (isValidUsfm[value]) {
+      it(`Convert ${value} to BibleNLP`, (inputUsfmPath=value) => {
+        //Tests if input parses without errors
+        const testParser = initialiseParser(inputUsfmPath)
+        assert(testParser instanceof USFMParser)
+        const json = testParser.toBibleNlpFormat();
+        assert("text" in json);
+        assert("vref" in json);
+        assert.strictEqual(json.text.length, json.vref.length);
+
+      });
+    }
+  });
+
+});
+
+describe("Test USJ to BibleNLP format conversion", () => {
+  allUsfmFiles.forEach(function(value) {
+    let filePath = value.replace(".usfm", ".json");
+    if (isValidUsfm[value] &&
+        fs.existsSync(filePath) && 
+        !filePath.endsWith("special-cases/empty-attributes/origin.json" )) {
+      it(`Convert ${filePath} to BibleNLP`, (inputUsjPath=filePath) => {
+        //Tests if input parses without errors
+        const rawData = fs.readFileSync(filePath, 'utf8');
+        const usj = JSON.parse(rawData)
+        const testParser = new USFMParser(null, usj);
+        assert(testParser instanceof USFMParser)
+        const json = testParser.toBibleNlpFormat();
+        assert("text" in json);
+        assert("vref" in json);
+        assert.strictEqual(json.text.length, json.vref.length);
+
+      });
+    }
+  });
+
 });

--- a/node-usfm-parser/test/test_list_conversion.js
+++ b/node-usfm-parser/test/test_list_conversion.js
@@ -61,7 +61,7 @@ describe("Test include Marker option in List conversion", () => {
                 const list = testParser.toList(null, inList);
                 assert(list instanceof Array);
 
-                const allTypes = list.slice(1).map(row => row[5]);
+                const allTypes = list.slice(1).map(row => row[5].replace(/\d+$/, ''));
                 assert( allTypes.every(element => inList.includes(element)), allTypes)
 
             });

--- a/py-usfm-parser/README.md
+++ b/py-usfm-parser/README.md
@@ -86,6 +86,21 @@ print(table_output)
 
 ```
 
+##### To convert to Bible NLP format
+Bible NLP format consists of two `txt` files: the first, with verse texts, one per line and the second, with corresponding references.
+
+```python
+dict_output = my_parser.to_bible_nlp_format() 
+#dict_output = my_parser.to_list(ignore_errors=True)
+
+with open("bible_nlp.txt", "w", encoding='utf-8') as out_file1:
+  out_file1.writelines(f"{verse}\n" for verse in dict_output['text'])
+
+with open("vref.txt", "w", encoding='utf-8') as out_file2:
+  out_file2.writelines(f"{ref}\n" for ref in dict_output['ref'])
+
+```
+
 ##### To round trip with USJ
 ```python
 from usfm_grammar import USFMParser, Filter
@@ -139,40 +154,34 @@ with open(test_xml_file, 'r', encoding='utf-8') as usx_file:
 ### From CLI
 
 ```
-usage: usfm-grammar [-h] [--in_format {usfm,usj,usx}]
-                    [--out_format {usj,table,syntax-tree,usx,markdown,usfm}]
-                    [--include_markers {book_headers,titles,...}]
-                    [--exclude_markers {book_headers,titles,...}]
-                    [--csv_col_sep CSV_COL_SEP] [--csv_row_sep CSV_ROW_SEP]
-                    [--ignore_errors] [--combine_text]
+usage: usfm-grammar [-h] [--in_format {usfm,usj,usx}] [--out_format {usj,table,syntax-tree,usx,markdown,usfm,bible-nlp}]
+                    [--include_markers {book_headers,titles,comments,paragraphs,characters,notes,study_bible,bcv,text,ide,usfm,h,toc,toca,imt,is,ip,ipi,im,imi,ipq,imq,ipr,iq,ib,ili,iot,io,iex,imte,ie,mt,mte,cl,cd,ms,mr,s,sr,r,d,sp,sd,sts,rem,lit,restore,p,m,po,pr,cls,pmo,pm,pmc,pmr,pi,mi,nb,pc,ph,q,qr,qc,qa,qm,qd,lh,li,lf,lim,litl,tr,tc,th,tcr,thr,table,b,add,bk,dc,ior,iqt,k,litl,nd,ord,pn,png,qac,qs,qt,rq,sig,sls,tl,wj,em,bd,bdit,it,no,sc,sup,rb,pro,w,wh,wa,wg,lik,liv,jmp,f,fe,ef,efe,x,ex,fr,ft,fk,fq,fqa,fl,fw,fp,fv,fdc,xo,xop,xt,xta,xk,xq,xot,xnt,xdc,esb,cat,id,c,v,text-in-excluded-parent}]
+                    [--exclude_markers {book_headers,titles,comments,paragraphs,characters,notes,study_bible,bcv,text,ide,usfm,h,toc,toca,imt,is,ip,ipi,im,imi,ipq,imq,ipr,iq,ib,ili,iot,io,iex,imte,ie,mt,mte,cl,cd,ms,mr,s,sr,r,d,sp,sd,sts,rem,lit,restore,p,m,po,pr,cls,pmo,pm,pmc,pmr,pi,mi,nb,pc,ph,q,qr,qc,qa,qm,qd,lh,li,lf,lim,litl,tr,tc,th,tcr,thr,table,b,add,bk,dc,ior,iqt,k,litl,nd,ord,pn,png,qac,qs,qt,rq,sig,sls,tl,wj,em,bd,bdit,it,no,sc,sup,rb,pro,w,wh,wa,wg,lik,liv,jmp,f,fe,ef,efe,x,ex,fr,ft,fk,fq,fqa,fl,fw,fp,fv,fdc,xo,xop,xt,xta,xk,xq,xot,xnt,xdc,esb,cat,id,c,v,text-in-excluded-parent}]
+                    [--csv_col_sep CSV_COL_SEP] [--csv_row_sep CSV_ROW_SEP] [--ignore_errors] [--combine_text]
                     infile
 
-Uses the tree-sitter-usfm grammar to parse and convert USFM to Syntax-tree,
-JSON, CSV, USX etc.
+Uses the tree-sitter-usfm grammar to parse and convert USFM to Syntax-tree, JSON, CSV, USX etc.
 
 positional arguments:
   infile                input usfm or usj file
 
 options:
   -h, --help            show this help message and exit
-  --in_format {usfm,usj}
+  --in_format {usfm,usj,usx}
                         input file format
-  --out_format {usj,table,syntax-tree,usx,markdown,usfm}
+  --out_format {usj,table,syntax-tree,usx,markdown,usfm,bible-nlp}
                         output format
   --include_markers {book_headers,titles,comments,paragraphs,characters,notes,study_bible,bcv,text,ide,usfm,h,toc,toca,imt,is,ip,ipi,im,imi,ipq,imq,ipr,iq,ib,ili,iot,io,iex,imte,ie,mt,mte,cl,cd,ms,mr,s,sr,r,d,sp,sd,sts,rem,lit,restore,p,m,po,pr,cls,pmo,pm,pmc,pmr,pi,mi,nb,pc,ph,q,qr,qc,qa,qm,qd,lh,li,lf,lim,litl,tr,tc,th,tcr,thr,table,b,add,bk,dc,ior,iqt,k,litl,nd,ord,pn,png,qac,qs,qt,rq,sig,sls,tl,wj,em,bd,bdit,it,no,sc,sup,rb,pro,w,wh,wa,wg,lik,liv,jmp,f,fe,ef,efe,x,ex,fr,ft,fk,fq,fqa,fl,fw,fp,fv,fdc,xo,xop,xt,xta,xk,xq,xot,xnt,xdc,esb,cat,id,c,v,text-in-excluded-parent}
                         the list of of contents to be included
   --exclude_markers {book_headers,titles,comments,paragraphs,characters,notes,study_bible,bcv,text,ide,usfm,h,toc,toca,imt,is,ip,ipi,im,imi,ipq,imq,ipr,iq,ib,ili,iot,io,iex,imte,ie,mt,mte,cl,cd,ms,mr,s,sr,r,d,sp,sd,sts,rem,lit,restore,p,m,po,pr,cls,pmo,pm,pmc,pmr,pi,mi,nb,pc,ph,q,qr,qc,qa,qm,qd,lh,li,lf,lim,litl,tr,tc,th,tcr,thr,table,b,add,bk,dc,ior,iqt,k,litl,nd,ord,pn,png,qac,qs,qt,rq,sig,sls,tl,wj,em,bd,bdit,it,no,sc,sup,rb,pro,w,wh,wa,wg,lik,liv,jmp,f,fe,ef,efe,x,ex,fr,ft,fk,fq,fqa,fl,fw,fp,fv,fdc,xo,xop,xt,xta,xk,xq,xot,xnt,xdc,esb,cat,id,c,v,text-in-excluded-parent}
                         the list of of contents to be included
   --csv_col_sep CSV_COL_SEP
-                        column separator or delimiter. Only useful with
-                        format=table.
+                        column separator or delimiter. Only useful with format=table.
   --csv_row_sep CSV_ROW_SEP
-                        row separator or delimiter. Only useful with
-                        format=table.
+                        row separator or delimiter. Only useful with format=table.
   --ignore_errors       to get some output from successfully parsed portions
-  --combine_text        to be used along with exclude_markers or
-                        include_markers, to concatinate the consecutive text
-                        snippets, from different components, or not
+  --combine_text        to be used along with exclude_markers or include_markers, to concatinate the consecutive text snippets, from different components, or not
+
 ```
 Example
 ```bash
@@ -185,6 +194,11 @@ Example
 >>> usfm-grammar sample.usfm --include_markers bcv --include_markers text --include_markers s
 
 >>> usfm-grammar sample-usj.json --out_format usfm
+```
+
+For the bible-nlp option, two files will be generated: `<name>_bible_nlp.txt` and `<name>_bible_nlp_vref.txt`. For all other `out_format` options, the output is displayed directly in the console (standard output). If needed, it can be redirected to a file using the following approach:
+```bash
+>>> usfm-grammar sample.usfm --out_format usx > converted_usx.xml
 ```
 
 ### Filtering on USJ

--- a/py-usfm-parser/README.md
+++ b/py-usfm-parser/README.md
@@ -93,11 +93,11 @@ Bible NLP format consists of two `txt` files: the first, with verse texts, one p
 dict_output = my_parser.to_biblenlp_format() 
 #dict_output = my_parser.to_biblenlp_format(ignore_errors=True)
 
-with open("bible_nlp.txt", "w", encoding='utf-8') as out_file1:
+with open("bibleNLP.txt", "w", encoding='utf-8') as out_file1:
   out_file1.writelines(f"{verse}\n" for verse in dict_output['text'])
 
 with open("vref.txt", "w", encoding='utf-8') as out_file2:
-  out_file2.writelines(f"{ref}\n" for ref in dict_output['ref'])
+  out_file2.writelines(f"{ref}\n" for ref in dict_output['vref'])
 
 ```
 

--- a/py-usfm-parser/README.md
+++ b/py-usfm-parser/README.md
@@ -86,12 +86,12 @@ print(table_output)
 
 ```
 
-##### To convert to Bible NLP format
+##### To convert to BibleNLP format
 Bible NLP format consists of two `txt` files: the first, with verse texts, one per line and the second, with corresponding references.
 
 ```python
-dict_output = my_parser.to_bible_nlp_format() 
-#dict_output = my_parser.to_list(ignore_errors=True)
+dict_output = my_parser.to_biblenlp_format() 
+#dict_output = my_parser.to_biblenlp_format(ignore_errors=True)
 
 with open("bible_nlp.txt", "w", encoding='utf-8') as out_file1:
   out_file1.writelines(f"{verse}\n" for verse in dict_output['text'])
@@ -196,7 +196,7 @@ Example
 >>> usfm-grammar sample-usj.json --out_format usfm
 ```
 
-For the bible-nlp option, two files will be generated: `<name>_bible_nlp.txt` and `<name>_bible_nlp_vref.txt`. For all other `out_format` options, the output is displayed directly in the console (standard output). If needed, it can be redirected to a file using the following approach:
+For the `biblenlp` option, two files will be generated: `<name>_biblenlp.txt` and `<name>_biblenlp_vref.txt`. For all other `out_format` options, the output is displayed directly in the console (standard output). If needed, it can be redirected to a file using the following approach:
 ```bash
 >>> usfm-grammar sample.usfm --out_format usx > converted_usx.xml
 ```

--- a/py-usfm-parser/src/usfm_grammar/__main__.py
+++ b/py-usfm-parser/src/usfm_grammar/__main__.py
@@ -136,9 +136,9 @@ def main(): #pylint: disable=too-many-locals
             print(my_parser.usfm)
         case Format.BIBLENLP:
             infile = arg_parser.parse_args().infile
-            outfile_name = "".join(infile.split(".")[:-1]) + "_bible_nlp.txt"
-            outfile_name2 = outfile_name.replace("_bible_nlp.txt", "_bible_nlp_vref.txt")
-            bible_nlp_dict = my_parser.to_bible_nlp_format(ignore_errors=ignore_errors)
+            outfile_name = "".join(infile.split(".")[:-1]) + "_biblenlp.txt"
+            outfile_name2 = outfile_name.replace("_biblenlp.txt", "_biblenlp_vref.txt")
+            bible_nlp_dict = my_parser.to_biblenlp_format(ignore_errors=ignore_errors)
             with open(outfile_name, 'w', encoding='utf-8') as out1:
                 out1.writelines(f"{line}\n" for line in bible_nlp_dict['text'])
             with open(outfile_name2, 'w', encoding="utf-8") as out2:

--- a/py-usfm-parser/src/usfm_grammar/__main__.py
+++ b/py-usfm-parser/src/usfm_grammar/__main__.py
@@ -105,33 +105,45 @@ def main(): #pylint: disable=too-many-locals
 
     output_format = arg_parser.parse_args().out_format
 
+    ignore_errors = arg_parser.parse_args().ignore_errors
+
     match output_format:
         case Format.JSON:
             dict_output = my_parser.to_usj(
                 exclude_markers=exclude_markers,
                 include_markers=include_markers,
-                ignore_errors=True)
+                ignore_errors=ignore_errors)
             print(json.dumps(dict_output, indent=4, ensure_ascii=False))
         case Format.CSV:
             table_output = my_parser.to_list(
                 exclude_markers=exclude_markers,
                 include_markers=include_markers,
-                ignore_errors=True)
+                ignore_errors=ignore_errors)
             outfile = sys.stdout
             writer = csv.writer(outfile,
                 delimiter=arg_parser.parse_args().csv_col_sep,
                 lineterminator=arg_parser.parse_args().csv_row_sep)
             writer.writerows(table_output)
         case Format.USX:
-            xmlstr = etree.tostring(my_parser.to_usx(ignore_errors=True),
+            xmlstr = etree.tostring(my_parser.to_usx(ignore_errors=ignore_errors),
                 encoding='unicode', pretty_print=True)
             print(xmlstr)
         case Format.MD:
             print(my_parser.to_markdown())
         case Format.ST:
-            print(my_parser.to_syntax_tree(ignore_errors=True))
+            print(my_parser.to_syntax_tree(ignore_errors=ignore_errors))
         case Format.USFM:
             print(my_parser.usfm)
+        case Format.BIBLENLP:
+            infile = arg_parser.parse_args().infile
+            outfile_name = "".join(infile.split(".")[:-1]) + "_bible_nlp.txt"
+            outfile_name2 = outfile_name.replace("_bible_nlp.txt", "_bible_nlp_vref.txt")
+            bible_nlp_dict = my_parser.to_bible_nlp_format(ignore_errors=ignore_errors)
+            with open(outfile_name, 'w', encoding='utf-8') as out1:
+                out1.writelines(f"{line}\n" for line in bible_nlp_dict['text'])
+            with open(outfile_name2, 'w', encoding="utf-8") as out2:
+                out2.writelines(f"{line}\n" for line in bible_nlp_dict['vref'])
+            print(f"Outputs written to {outfile_name} and {outfile_name2}.")
         case _:
             raise Exception(f"Un-recognized output format:{output_format}!")
 

--- a/py-usfm-parser/src/usfm_grammar/list_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/list_generator.py
@@ -57,14 +57,14 @@ class ListGenerator:
         elif obj['type'] == "verse":
             self.usj_to_list_v(obj)
         marker_type = obj['type']
-        marker_name = obj['marker'] if "marker" in obj else ''
         if marker_type == "USJ":
             # This would occur if the JSON got flatttened after removing paragraph markers
             marker_type = ""
         if marker_type != "book" and 'content' in obj:
             for item in obj['content']:
                 if isinstance(item, str):
-                    if self.current_chapter == self.prev_chapter and self.current_verse==self.prev_verse:
+                    if self.current_chapter == self.prev_chapter and \
+                        self.current_verse==self.prev_verse:
                         self.bible_nlp_format["text"][-1] += " "+item.replace("\n", " ").strip()
                     else:
                         vref = f"{self.book} {self.current_chapter}:{self.current_verse}"
@@ -74,4 +74,3 @@ class ListGenerator:
                         self.prev_verse = self.current_verse
                 else:
                     self.usj_to_bible_nlp_format(item)
-

--- a/py-usfm-parser/src/usfm_grammar/list_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/list_generator.py
@@ -1,4 +1,4 @@
-'''Logics for USJ to list(table) conversions'''
+'''Logics for USJ to list(table) and Bible NLP format conversions'''
 
 
 class ListGenerator:
@@ -9,6 +9,9 @@ class ListGenerator:
         self.current_chapter = ""
         self.current_verse = ""
         self.list = [["Book","Chapter","Verse","Text","Type","Marker"]]
+        self.bible_nlp_format = { "text" : [], "vref":[] }
+        self.prev_chapter = ""
+        self.prev_verse = ""
 
     def usj_to_list_id(self, obj):
         '''update book code'''
@@ -43,3 +46,32 @@ class ListGenerator:
                             item, marker_type, marker_name])
                 else:
                     self.usj_to_list(item)
+
+
+    def usj_to_bible_nlp_format(self, obj):
+        '''Traverse the USJ dict and build a dict for bible nlp format, in self.bible_nlp_format'''
+        if obj['type'] == "book":
+            self.usj_to_list_id(obj)
+        elif obj['type'] == "chapter":
+            self.usj_to_list_c(obj)
+        elif obj['type'] == "verse":
+            self.usj_to_list_v(obj)
+        marker_type = obj['type']
+        marker_name = obj['marker'] if "marker" in obj else ''
+        if marker_type == "USJ":
+            # This would occur if the JSON got flatttened after removing paragraph markers
+            marker_type = ""
+        if marker_type != "book" and 'content' in obj:
+            for item in obj['content']:
+                if isinstance(item, str):
+                    if self.current_chapter == self.prev_chapter and self.current_verse==self.prev_verse:
+                        self.bible_nlp_format["text"][-1] += " "+item.replace("\n", " ").strip()
+                    else:
+                        vref = f"{self.book} {self.current_chapter}:{self.current_verse}"
+                        self.bible_nlp_format["text"].append(item.replace("\n", " ").strip())
+                        self.bible_nlp_format["vref"].append(vref)
+                        self.prev_chapter = self.current_chapter
+                        self.prev_verse = self.current_verse
+                else:
+                    self.usj_to_bible_nlp_format(item)
+

--- a/py-usfm-parser/src/usfm_grammar/list_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/list_generator.py
@@ -48,7 +48,7 @@ class ListGenerator:
                     self.usj_to_list(item)
 
 
-    def usj_to_bible_nlp_format(self, obj):
+    def usj_to_biblenlp_format(self, obj):
         '''Traverse the USJ dict and build a dict for bible nlp format, in self.bible_nlp_format'''
         if obj['type'] == "book":
             self.usj_to_list_id(obj)
@@ -73,4 +73,4 @@ class ListGenerator:
                         self.prev_chapter = self.current_chapter
                         self.prev_verse = self.current_verse
                 else:
-                    self.usj_to_bible_nlp_format(item)
+                    self.usj_to_biblenlp_format(item)

--- a/py-usfm-parser/src/usfm_grammar/usfm_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_generator.py
@@ -27,6 +27,11 @@ class USFMGenerator:
         '''Traverses through the dict/json and uses 'type' field to form USFM elements'''
         if not isinstance(usj_obj, dict) or "type" not in usj_obj:
             raise Exception("Unable to do the conversion. Ensure USJ is valid!")
+        if usj_obj['type'] == "optbreak":
+            if self.usfm_string != "" and self.usfm_string[-1] not in ["\n", "\r", " ", "\t"]:
+                self.usfm_string += " "
+            self.usfm_string += "// "
+            return
         if usj_obj['type'] == "ref":
             usj_obj['marker'] = "ref"
         if usj_obj['type'] not in NO_USFM_USJ_TYPES:

--- a/py-usfm-parser/src/usfm_grammar/usfm_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_generator.py
@@ -2,7 +2,7 @@
 
 NO_USFM_USJ_TYPES = ['USJ', 'table']
 NO_NEWLINE_USJ_TYPES = ['char', 'note', 'verse', 'table:cell']
-CLOSING_USJ_TYPES = ['char', 'note', 'figure']
+CLOSING_USJ_TYPES = ['char', 'note', 'figure', 'ref']
 NON_ATTRIB_USJ_KEYS = ['type', 'marker', 'content', 'number', 'sid',
                         'code', 'caller', 'align',
                         'version', 'altnumber', 'pubnumber', 'category']
@@ -27,6 +27,8 @@ class USFMGenerator:
         '''Traverses through the dict/json and uses 'type' field to form USFM elements'''
         if not isinstance(usj_obj, dict) or "type" not in usj_obj:
             raise Exception("Unable to do the conversion. Ensure USJ is valid!")
+        if usj_obj['type'] == "ref":
+            usj_obj['marker'] = "ref"
         if usj_obj['type'] not in NO_USFM_USJ_TYPES:
             self.usfm_string += "\\"
             if nested and usj_obj['type'] == 'char' and\

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -220,7 +220,7 @@ class USFMParser():
         return list_generator.list
 
     def to_bible_nlp_format(self, ignore_errors=False):
-        '''uses the toUSJ function with BCV and TEXT filters, 
+        '''uses the toUSJ function with BCV and TEXT filters,
         and converts the JSON to lists of texts and vrefs.'''
         if not ignore_errors and self.errors:
             err_str = "\n\t".join([":".join(err) for err in self.errors])

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -49,7 +49,7 @@ class Format(str, Enum):
     USX = "usx"
     MD = "markdown"
     USFM = "usfm"
-    BIBLENLP = "bible-nlp"
+    BIBLENLP = "biblenlp"
 
 USFM_LANGUAGE = Language(tsusfm.language())
 parser = Parser(USFM_LANGUAGE)
@@ -219,7 +219,7 @@ class USFMParser():
             raise Exception(message)  from exe
         return list_generator.list
 
-    def to_bible_nlp_format(self, ignore_errors=False):
+    def to_biblenlp_format(self, ignore_errors=False):
         '''uses the toUSJ function with BCV and TEXT filters,
         and converts the JSON to lists of texts and vrefs.'''
         if not ignore_errors and self.errors:
@@ -240,7 +240,7 @@ class USFMParser():
             usj_dict = include_markers_in_usj(usj_dict, Filter.BCV+Filter.TEXT, True)
 
             list_generator = ListGenerator()
-            list_generator.usj_to_bible_nlp_format(usj_dict)
+            list_generator.usj_to_biblenlp_format(usj_dict)
         except Exception as exe:
             message = "Unable to do the conversion. "
             if self.errors:

--- a/py-usfm-parser/tests/test_list_conversion.py
+++ b/py-usfm-parser/tests/test_list_conversion.py
@@ -49,11 +49,11 @@ def test_list_converions_with_include_markers(file_path, include_markers):
 
 @pytest.mark.parametrize('file_path', test_files)
 @pytest.mark.timeout(30)
-def test_usfm_to_bible_nlp_conversion(file_path):
+def test_usfm_to_biblenlp_conversion(file_path):
     '''Tests if input parses without errors'''
     test_parser = initialise_parser(file_path)
     assert not test_parser.errors, test_parser.errors
-    bible_nlp_dict = test_parser.to_bible_nlp_format()
+    bible_nlp_dict = test_parser.to_biblenlp_format()
     assert isinstance(bible_nlp_dict, dict)
     assert "text" in bible_nlp_dict
     assert "vref" in bible_nlp_dict
@@ -61,7 +61,7 @@ def test_usfm_to_bible_nlp_conversion(file_path):
 
 @pytest.mark.parametrize('file_path', test_files)
 @pytest.mark.timeout(30)
-def test_usj_to_bible_nlp_conversion(file_path):
+def test_usj_to_biblenlp_conversion(file_path):
     '''Tests if input parses without errors'''
     usj_path = file_path.replace("usfm", "json")
     if os.path.isfile(usj_path) and "special-cases/empty-attributes/origin.json" not in usj_path:
@@ -69,7 +69,7 @@ def test_usj_to_bible_nlp_conversion(file_path):
             usj = json.load(usj_fp)
             test_parser = USFMParser(from_usj=usj)
             assert not test_parser.errors, test_parser.errors
-            bible_nlp_dict = test_parser.to_bible_nlp_format()
+            bible_nlp_dict = test_parser.to_biblenlp_format()
             assert isinstance(bible_nlp_dict, dict)
             assert "text" in bible_nlp_dict
             assert "vref" in bible_nlp_dict

--- a/web-usfm-parser/README.md
+++ b/web-usfm-parser/README.md
@@ -124,6 +124,34 @@ const usfmParser2 = new USFMParser(usfmString=null, fromUsj=null, fromUsx=usxEle
 const usfmGen = usfmParser2.usfm;
 console.log(usfmGen);
 ```
+### BibleNLP format
+Bible NLP format consists of two `txt` files: the first, with verse texts, one per line and the second, with corresponding references. The API generates a JSON with two fields, `text` and `vref`, each containing an array of strings.
+
+```javascript
+
+const output = usfmParser.toBibleNlpFormat() 
+//const output = my_parser.toBibleNlpFormat(true) //ignore_errors
+
+const textLines = output.text.join('\n');
+fs.writeFileSync('bibleNLP.txt', textLines, { encoding: 'utf-8' });
+
+const refLines = output.vref.join('\n');
+fs.writeFileSync('vref.txt', refLines, { encoding: 'utf-8' });
+```
+
+### Table/List format
+
+```javascript
+const listOutput = usfmParser.toList();
+/* const listOutput = usfmParser.toList(
+                      Filter.NOTES,  //exclude
+                      ["id", "c", "v"] //include
+                      true,  //ignore errors
+                      true  //combine texts
+                      )*/
+const tableOutput = listOutput.map(row => row.join('\t')).join('\n');
+console.log(tableOutput);
+```
 
 ### Autofix and Validation
 Experimental Validation and Autofix feature for USFM:
@@ -193,9 +221,9 @@ The filtering on USJ, the JSON output, is a feature incorporated to allow data e
     ```
     To inspect which are the markers in each of these options, it could be just printed out, `print(Filter.TITLES)`. These could be used individually or concatinated to get the desired filtering of markers and data:
     ```javascript
-    output = usfmParser.toUSJ(null, include_markers=Filter.BCV)
-    output = usfmParser.toUSJ(null, include_markers=Filter.BCV+Filter.TEXT)
-    output = usfmParser.toUSJ(exclude_markers=Filter.PARAGRAPHS+Filter.CHARACTERS)
+    output = usfmParser.toUSJ(null, Filter.BCV) //to include
+    output = usfmParser.toUSJ(null, [...Filter.BCV, ...Filter.TEXT]) //to include
+    output = usfmParser.toUSJ([...Filter.PARAGRAPHS, ...Filter.CHARACTERS]) //to exclude
     ``` 
 - Inner contents of excluded markers
 

--- a/web-usfm-parser/src/listGenerator.js
+++ b/web-usfm-parser/src/listGenerator.js
@@ -6,6 +6,9 @@ class ListGenerator {
         this.currentChapter = "";
         this.currentVerse = "";
         this.list = [["Book", "Chapter", "Verse", "Text", "Type", "Marker"]];
+        this.bibleNlpFormat = { "text" : [], "vref":[] }
+        this.prevChapter = ""
+        this.prevVerse = ""
     }
 
     usjToListId(obj) {
@@ -51,6 +54,36 @@ class ListGenerator {
             }
         }
     }
+
+    usjToBibleNlpFormat(obj) {
+        // Traverse the USJ object and build a dictionary for Bible NLP format
+        if (obj.type === "book") {
+            this.usjToListId(obj);
+        } else if (obj.type === "chapter") {
+            this.usjToListC(obj);
+        } else if (obj.type === "verse") {
+            this.usjToListV(obj);
+        } else if ( obj.content) {
+            for (const item of obj.content) {
+                if (typeof item === "string") {
+                    if (this.currentChapter === this.prevChapter &&
+                        this.currentVerse === this.prevVerse) {
+                        this.bibleNlpFormat.text[this.bibleNlpFormat.text.length - 1] +=
+                            " " + item.replace(/[\n\r]/g, " ").trim();
+                    } else {
+                        const vref = `${this.book} ${this.currentChapter}:${this.currentVerse}`;
+                        this.bibleNlpFormat.text.push(item.replace(/[\n\r]/g, " ").trim());
+                        this.bibleNlpFormat.vref.push(vref);
+                        this.prevChapter = this.currentChapter;
+                        this.prevVerse = this.currentVerse;
+                    }
+                } else {
+                    this.usjToBibleNlpFormat(item);
+                }
+            }
+        }
+    }
+
 }
 
 export default ListGenerator;

--- a/web-usfm-parser/src/usfmGenerator.js
+++ b/web-usfm-parser/src/usfmGenerator.js
@@ -51,7 +51,7 @@ class USFMGenerator {
         if (typeof item === "string") {
           this.usfmString += item;
         } else {
-          this.usjToUsfm(item, usjObj.type === "char");
+          this.usjToUsfm(item, usjObj.type === "char"  && item.marker !== "fv");
         }
       });
     }
@@ -59,7 +59,9 @@ class USFMGenerator {
     let attributes = [];
     Object.keys(usjObj).forEach((key) => {
       if (!NON_ATTRIB_USJ_KEYS.includes(key)) {
-        attributes.push(`${key}="${usjObj[key]}"`);
+        let lhs = key;
+        if (key === "file") { lhs = "src" }
+        attributes.push(`${lhs}="${usjObj[key]}"`);
       }
     });
 
@@ -73,6 +75,18 @@ class USFMGenerator {
         this.usfmString += "+";
       }
       this.usfmString += `${usjObj.marker}* `;
+    }
+    if (usjObj.type === "ms") {
+        if ("sid" in usjObj) {
+            if (attributes.length == 0 ) {
+                this.usfmString += '|';
+            }
+            this.usfmString += `sid="${usjObj.sid}" `;
+        }
+        this.usfmString = this.usfmString.trim() + "\\*";
+    }
+    if (usjObj.type === "sidebar" ) {
+        this.usfmString += "\\esbe";
     }
     if (
       !NO_NEWLINE_USJ_TYPES.includes(usjObj.type) &&

--- a/web-usfm-parser/src/usfmGenerator.js
+++ b/web-usfm-parser/src/usfmGenerator.js
@@ -7,6 +7,13 @@ class USFMGenerator {
   }
 
   usjToUsfm(usjObj, nested = false) {
+    if (usjObj.type === 'optbreak') {
+        if (this.usfmString !== '' && !['\n', '\r', ' ', '\t'].includes(this.usfmString.slice(-1))) {
+                this.usfmString += ' ';
+            }
+        this.usfmString += '// ';
+        return
+    }
     if (usjObj.type === "ref") {
         usjObj.marker = "ref";
     }

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -256,6 +256,32 @@ Only one of USFM, USJ or USX is supported in one object.`)
 
 	}
 
+	toBibleNlpFormat(ignoreErrors = false) {
+	    /* Uses the toUSJ function with only BVC and text.
+	       Then the JSOn is converted to list of verse texts and vrefs*/
+
+	    if (!ignoreErrors && this.errors.length > 0) {
+			let errorString = this.errors.join("\n\t");
+	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
+	    }
+
+	    try {
+	        const usjDict = this.toUSJ(null, [...Filter.BCV, ...Filter.TEXT], ignoreErrors, true);
+	        const listGenerator = new ListGenerator();
+	        listGenerator.usjToBibleNlpFormat(usjDict);
+	    	return listGenerator.bibleNlpFormat;
+
+	    } catch (exe) {
+	        let message = "Unable to do the conversion. ";
+	        if (this.errors.length > 0) {
+				let errorString = this.errors.join("\n\t");
+	            message += `Could be due to an error in the USFM\n\t${errorString}`;
+	        }
+	        throw new Error(message, { cause: exe });
+	    }
+
+	}
+
 	toUSX(ignoreErrors = false) {
 	    /* Convert the syntax_tree to the XML format (USX) */
 

--- a/web-usfm-parser/src/utils/types.js
+++ b/web-usfm-parser/src/utils/types.js
@@ -1,6 +1,6 @@
 export const NO_USFM_USJ_TYPES = ["USJ", "table"];
 export const CLOSING_USJ_TYPES
-  = ["char", "note", "figure"];
+  = ["char", "note", "figure", "ref"];
 export const NON_ATTRIB_USJ_KEYS = [
   "type",
   "marker",

--- a/web-usfm-parser/test/test_list_conversion.js
+++ b/web-usfm-parser/test/test_list_conversion.js
@@ -50,7 +50,7 @@ describe("Test Exclude Marker option in List conversion", () => {
 describe("Test include Marker option in List conversion", () => {
     // Test include Maker option by checking markers in the List
     const includeTests = [
-            ['id', 'c', 'v']+Filter.TEXT+Filter.PARAGRAPHS
+            ['id', 'c', 'v', ...Filter.TEXT, ...Filter.PARAGRAPHS]
             ]
     includeTests.forEach(function(inList) {
         allUsfmFiles.forEach(function(value) {
@@ -61,11 +61,52 @@ describe("Test include Marker option in List conversion", () => {
                 const list = testParser.toList(null, inList);
                 assert(list instanceof Array);
 
-                const allTypes = list.slice(1).map(row => row[5]);
+                const allTypes = list.slice(1).map(row => row[5].replace(/\d+$/, ''));
                 assert( allTypes.every(element => inList.includes(element)), allTypes)
 
             });
           }
         })
     })
+});
+
+describe("Test USFM to BibleNLP format conversion", () => {
+  allUsfmFiles.forEach(function(value) {
+    if (isValidUsfm[value]) {
+      it(`Convert ${value} to BibleNLP`, async (inputUsfmPath=value) => {
+        //Tests if input parses without errors
+        const testParser = await initialiseParser(inputUsfmPath)
+        assert(testParser instanceof USFMParser)
+        const json = testParser.toBibleNlpFormat();
+        assert("text" in json);
+        assert("vref" in json);
+        assert.strictEqual(json.text.length, json.vref.length);
+
+      });
+    }
+  });
+
+});
+
+describe("Test USJ to BibleNLP format conversion", () => {
+  allUsfmFiles.forEach(function(value) {
+    let filePath = value.replace(".usfm", ".json");
+    if (isValidUsfm[value] &&
+        fs.existsSync(filePath) && 
+        !filePath.endsWith("special-cases/empty-attributes/origin.json" )) {
+      it(`Convert ${filePath} to BibleNLP`, async (inputUsjPath=filePath) => {
+        //Tests if input parses without errors
+        const rawData = fs.readFileSync(filePath, 'utf8');
+        const usj = JSON.parse(rawData)
+        const testParser = new USFMParser(null, usj);
+        assert(testParser instanceof USFMParser)
+        const json = testParser.toBibleNlpFormat();
+        assert("text" in json);
+        assert("vref" in json);
+        assert.strictEqual(json.text.length, json.vref.length);
+
+      });
+    }
+  });
+
 });


### PR DESCRIPTION
- Fixes some issues noticed in USFM generation from USJ(`ref` and `optbreak` handling).
- Implements #244 . 
   - In python, node and web modules.
   - API: `USFMParser.to_biblenlp_format() --> {"text": [ ], "vref": [ ] }` and `USFMParser.toBibleNlpFormat() --> {"text": [ ], "vref": [ ] }` .
   - CLI(in python): `usfm-grammar --out_format biblenlp sample.usfm` generates `sample_biblenlp.txt` and `sample_biblenlp_vref.txt` files.
   - Mapping to ORIG versification not done yet.
- :warning:  The bible-nlp format follows a whole-bible-in-one-file format, where as USFM/USX/USJ keeps one-book-per-file. The converted text files will correspond to only one book which may have to be combined outside of usfm-grammar. (This can get more complex when conforming to ORIG versification).
- :warning: In CLI, this format needs 2 output files unlike the other supported formats. Other format outputs are written to the console. But this format is written to files created by the tool.