### PR TITLE
List with bcv

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1-alpha.1
+current_version = 3.0.1-alpha.2
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\-(?P<release>\w+)\.(?P<num>\d+))?

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar",
-  "version": "3.0.1-alpha.1",
+  "version": "3.0.1-alpha.2",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CSV, and converts them back to USFM",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/es/index.mjs",
@@ -28,7 +28,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "tree-sitter": "0.21.1",
-    "tree-sitter-usfm3": "3.0.1-alpha.1",
+    "tree-sitter-usfm3": "3.0.1-alpha.2",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
   },

--- a/node-usfm-parser/src/filters.js
+++ b/node-usfm-parser/src/filters.js
@@ -98,7 +98,7 @@ function combineConsecutiveTextContents(contentsList) {
 function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excludedParent = false) {
   let cleanedKids = [];
   if (typeof inputUsj === 'string') {
-    if (excludedParent || excludeMarkers.includes('text-in-excluded-parent')) {
+    if (excludedParent && excludeMarkers.includes('text-in-excluded-parent')) {
       return [];
     }
     return [inputUsj];
@@ -121,7 +121,6 @@ function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excl
       innerContentNeeded = false;
     }
   }
-
   if ((thisMarkerNeeded || innerContentNeeded) && "content" in inputUsj) {
     inputUsj.content.forEach(item => {
       let cleaned = excludeMarkersInUsj(item, excludeMarkers, combineTexts, excludedParent);
@@ -140,17 +139,20 @@ function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excl
     inputUsj.content = cleanedKids;
     return inputUsj;
   }
-  return cleanedKids;
+  if (innerContentNeeded) {
+    return cleanedKids;
+  }
+  return []
 }
 
 function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excludedParent = false) {
   let cleanedKids = [];
   
   if (typeof inputUsj === 'string') {
-    if (includeMarkers.includes(Filter.TEXT[0])) {
-      return [inputUsj]
-    } 
-    return []
+    if (excludedParent && !includeMarkers.includes("text-in-excluded-parent") ){
+      return []
+    }
+    return [inputUsj]
   }
   let thisMarker = '';
   if ('marker' in inputUsj) {
@@ -193,7 +195,10 @@ function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excl
     inputUsj.content = cleanedKids;
     return inputUsj;
   }
-  return cleanedKids;
+  if (innerContentNeeded){
+    return cleanedKids;
+  }
+  return [];
 }
  
 

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -223,7 +223,9 @@ Only one of USFM, USJ or USX is supported in one object.`)
 	    }
 
 	    try {
-	    	includeMarkers = [...includeMarkers, ...Filter.BCV]
+	    	if (includeMarkers) { 
+	    		includeMarkers = [...includeMarkers, ...Filter.BCV]
+	    	}
 	        const usjDict = this.toUSJ(excludeMarkers, includeMarkers, ignoreErrors, combineTexts);
 
 	        const listGenerator = new ListGenerator();

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -223,6 +223,7 @@ Only one of USFM, USJ or USX is supported in one object.`)
 	    }
 
 	    try {
+	    	includeMarkers = [...includeMarkers, ...Filter.BCV]
 	        const usjDict = this.toUSJ(excludeMarkers, includeMarkers, ignoreErrors, combineTexts);
 
 	        const listGenerator = new ListGenerator();

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.1-alpha.1"
+version = "3.0.1-alpha.2"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["usfm", "parser", "grammar", "tree-sitter"]
 dependencies = [
     'tree-sitter==0.22.3; python_version >= "3.9"',
-    'tree-sitter-usfm3==3.0.1-alpha.1; python_version >="3.8"',
+    'tree-sitter-usfm3==3.0.1-alpha.2; python_version >="3.8"',
     'lxml==5.2.2; python_version >= "3.5"',
     'jsonschema==4.23.0; python_version>= "3.8"'
 ]

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,4 +1,4 @@
 tree-sitter==0.22.3
-tree-sitter-usfm3==3.0.1-alpha.1
+tree-sitter-usfm3==3.0.1-alpha.2
 lxml==5.2.2
 jsonschema==4.23.0

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.1-alpha.1",  # Required
+    version="3.0.1-alpha.2",  # Required
     python_requires=">=3.10",
     # install_requires=["tree-sitter==0.22.3",
                         # "tree-sitter-usfm3==3.0.0-beta.7",  

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -9,4 +9,4 @@ USFMParser = usfm_parser.USFMParser
 
 Validator = validator.Validator
 
-__version__ = "3.0.1-alpha.1"
+__version__ = "3.0.1-alpha.2"

--- a/tests/bugfixes/rem_with_char/metadata.xml
+++ b/tests/bugfixes/rem_with_char/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <test-metadata>
-        <description>Rem is allowed in different places in the file and can take character markups.</description>
+        <description>Rem is allowed in different places in the file and can take character markups. https://github.com/Bridgeconn/usfm-grammar/issues/299 </description>
         <validated>pass</validated>
         <tags></tags>
 </test-metadata>

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.1-alpha.1",
+  "version": "3.0.1-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-usfm3",
-      "version": "3.0.1-alpha.1",
+      "version": "3.0.1-alpha.2",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {
@@ -235,7 +235,7 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.1-alpha.1",
+      "version": "3.0.1-alpha.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
@@ -538,7 +538,7 @@
       }
     },
     "pump": {
-      "version": "3.0.1-alpha.1",
+      "version": "3.0.1-alpha.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.1-alpha.1",
+  "version": "3.0.1-alpha.2",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/tree-sitter-usfm3/pyproject.toml
+++ b/tree-sitter-usfm3/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-usfm3"
 description = "Usfm3 grammar for tree-sitter"
-version = "3.0.1-alpha.1"
+version = "3.0.1-alpha.2"
 keywords = ["incremental", "parsing", "tree-sitter", "usfm3"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/web-usfm-parser/README.md
+++ b/web-usfm-parser/README.md
@@ -23,10 +23,10 @@ function App() {
 
   useEffect(() => {
     const initParser = async () => {
-      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter.wasm");
-      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter.wasm");
+      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter.wasm");
+      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter.wasm");
 
     };
     initParser();
@@ -60,13 +60,13 @@ It can be used directly in the HTML script tag too. Please ensure its dependenci
 
 ```html
 <script type="module">
-  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/dist/bundle.mjs';
+  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/dist/bundle.mjs';
   console.log('Hello world');
   (async () => {
-  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter.wasm");
-  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.1/tree-sitter.wasm");
+  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter.wasm");
+  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.2/tree-sitter.wasm");
   const usfmParser = new USFMParser('\\id GEN\n\\c 1\n\\p\n\\v 1 In the begining..\\v 2 more text')
   const output = usfmParser.toUSJ()
   console.log({ output })

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar-web",
-  "version": "3.0.1-alpha.1",
+  "version": "3.0.1-alpha.2",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CS, and converts them back to USFM.",
   "type": "module",
   "module": "dist/bundle.mjs",

--- a/web-usfm-parser/src/filters.js
+++ b/web-usfm-parser/src/filters.js
@@ -98,7 +98,7 @@ function combineConsecutiveTextContents(contentsList) {
 function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excludedParent = false) {
   let cleanedKids = [];
   if (typeof inputUsj === 'string') {
-    if (excludedParent || excludeMarkers.includes('text-in-excluded-parent')) {
+    if (excludedParent && excludeMarkers.includes('text-in-excluded-parent')) {
       return [];
     }
     return [inputUsj];
@@ -140,17 +140,20 @@ function excludeMarkersInUsj(inputUsj, excludeMarkers, combineTexts = true, excl
     inputUsj.content = cleanedKids;
     return inputUsj;
   }
-  return cleanedKids;
+  if (innerContentNeeded){
+    return cleanedKids;
+  }
+  return [];
 }
 
 function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excludedParent = false) {
   let cleanedKids = [];
   
   if (typeof inputUsj === 'string') {
-    if (includeMarkers.includes(Filter.TEXT[0])) {
-      return [inputUsj]
+    if (excludedParent && !includeMarkers.includes("text-in-excluded-parent")) {
+      return [];
     } 
-    return []
+    return [inputUsj];
   }
   let thisMarker = '';
   if ('marker' in inputUsj) {
@@ -193,7 +196,10 @@ function includeMarkersInUsj(inputUsj, includeMarkers, combineTexts = true, excl
     inputUsj.content = cleanedKids;
     return inputUsj;
   }
-  return cleanedKids;
+  if (innerContentNeeded){
+    return cleanedKids;
+  }
+  return [];
 }
  
 export { Filter };

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -239,7 +239,9 @@ Only one of USFM, USJ or USX is supported in one object.`)
 	    }
 
 	    try {
-	    	includeMarkers = [...includeMarkers, ...Filter.BCV]
+	    	if (includeMarkers) {
+	    		includeMarkers = [...includeMarkers, ...Filter.BCV]
+	    	}
 	        const usjDict = this.toUSJ(excludeMarkers, includeMarkers, ignoreErrors, combineTexts);
 
 	        const listGenerator = new ListGenerator();

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -239,6 +239,7 @@ Only one of USFM, USJ or USX is supported in one object.`)
 	    }
 
 	    try {
+	    	includeMarkers = [...includeMarkers, ...Filter.BCV]
 	        const usjDict = this.toUSJ(excludeMarkers, includeMarkers, ignoreErrors, combineTexts);
 
 	        const listGenerator = new ListGenerator();


### PR DESCRIPTION
- Implements #305 
  - Python was already had this behaviour.
  - Updated Node and Web modules
- In node and web, when excluding paragraphs, its inner conntents were also getting lost. Fixes this aswell. 
- Adds link to the corresponding issue where discussion of \rem having char is, in the test case description added for it.