### PR TITLE
For 3.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1-alpha.4
+current_version = 3.1.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\-(?P<release>\w+)\.(?P<num>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1-alpha.3
+current_version = 3.0.1-alpha.4
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\-(?P<release>\w+)\.(?P<num>\d+))?

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar",
-  "version": "3.0.1-alpha.3",
+  "version": "3.0.1-alpha.4",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CSV, and converts them back to USFM",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/es/index.mjs",
@@ -28,7 +28,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "tree-sitter": "0.21.1",
-    "tree-sitter-usfm3": "3.0.1-alpha.3",
+    "tree-sitter-usfm3": "3.0.1-alpha.4",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
   },

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar",
-  "version": "3.0.1-alpha.4",
+  "version": "3.1.0",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CSV, and converts them back to USFM",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/es/index.mjs",
@@ -28,7 +28,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "tree-sitter": "0.21.1",
-    "tree-sitter-usfm3": "3.0.1-alpha.4",
+    "tree-sitter-usfm3": "3.1.0",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
   },

--- a/node-usfm-parser/src/listGenerator.js
+++ b/node-usfm-parser/src/listGenerator.js
@@ -6,9 +6,9 @@ class ListGenerator {
         this.currentChapter = "";
         this.currentVerse = "";
         this.list = [["Book", "Chapter", "Verse", "Text", "Type", "Marker"]];
-        this.bibleNlpFormat = { "text" : [], "vref":[] }
-        this.prevChapter = ""
-        this.prevVerse = ""
+        this.bibleNlpFormat = { "text" : [], "vref":[] };
+        this.prevChapter = "";
+        this.prevVerse = "";
     }
 
     usjToListId(obj) {
@@ -19,6 +19,7 @@ class ListGenerator {
     usjToListC(obj) {
         /* Update current chapter */
         this.currentChapter = obj.number;
+        this.currentVerse = "";
     }
 
     usjToListV(obj) {
@@ -26,10 +27,14 @@ class ListGenerator {
         this.currentVerse = obj.number;
     }
 
-    usjToList(obj) {
+    usjToList(obj, excludeMarkers=null, includeMarkers=null) {
         /* Traverse the USJ dict and build the table in this.list */
         if (obj.type === "book") {
             this.usjToListId(obj);
+            if ((excludeMarkers && excludeMarkers.includes("id")) ||
+                (includeMarkers && !includeMarkers.includes("id"))) {
+                return
+            }
         } else if (obj.type === "chapter") {
             this.usjToListC(obj);
         } else if (obj.type === "verse") {
@@ -47,10 +52,19 @@ class ListGenerator {
         if (obj.content) {
             for (let item of obj.content) {
                 if (typeof item === "string") {
+                    if (excludeMarkers && excludeMarkers.includes("text")){
+                        item = "";
+                    }
                     this.list.push([this.book, this.currentChapter, this.currentVerse, item, markerType, markerName]);
                 } else {
-                    this.usjToList(item);
+                    this.usjToList(item, excludeMarkers, includeMarkers);
                 }
+            }
+        } else {
+            if ((!excludeMarkers && !includeMarkers) ||
+                (excludeMarkers && !excludeMarkers.includes(markerName)) ||
+                (includeMarkers && includeMarkers.includes(markerName))) {
+                this.list.push([this.book, this.currentChapter, this.currentVerse, "", markerType, markerName])
             }
         }
     }

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -40,8 +40,8 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.`)
         }
 
         if (usfmString !== null) {
-        	if (typeof usfmString !== "string" || usfmString === null) {
-				throw new Error("Invalid input for USFM. Expected a string.");
+        	if (typeof usfmString !== "string" || !usfmString.trim().startsWith("\\")) {
+				throw new Error("Invalid input for USFM. Expected a string with \\ markups.");
 			}
             this.usfm = usfmString;
         } else if(fromUsj !== null) {

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -280,13 +280,19 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.`)
 	    }
 
 	    try {
+	        let excludeList = null;
+	        let includeList = null;
 	    	if (includeMarkers) { 
-	    		includeMarkers = [...includeMarkers, ...Filter.BCV]
+	    		includeList = [...includeMarkers, ...Filter.BCV];
 	    	}
-	        const usjDict = this.toUSJ(excludeMarkers, includeMarkers, ignoreErrors, combineTexts);
+	    	if (excludeMarkers) {
+	    		excludeList = excludeMarkers.filter(item => !Filter.BCV.includes(item));
+
+	    	}
+    		const usjDict = this.toUSJ(excludeList, includeList, ignoreErrors, combineTexts);
 
 	        const listGenerator = new ListGenerator();
-	        listGenerator.usjToList(usjDict);
+	        listGenerator.usjToList(usjDict, excludeMarkers, includeMarkers);
 	    	return listGenerator.list;
 
 	    } catch (exe) {

--- a/node-usfm-parser/test/basic.js
+++ b/node-usfm-parser/test/basic.js
@@ -72,7 +72,7 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.` )
       const usfmParser = new USFMParser(usfmString=simpleUSJ)
 
     } catch(err) {
-      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string.")
+      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string with \\ markups.")
     }
     assert.strictEqual(usfmParser, null);
   });
@@ -94,7 +94,7 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.` )
       const usfmParser = new USFMParser(simpleUSJ)
 
     } catch(err) {
-      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string.")
+      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string with \\ markups.")
     }
     assert.strictEqual(usfmParser, null);
   });

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.1-alpha.3"
+version = "3.0.1-alpha.4"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["usfm", "parser", "grammar", "tree-sitter"]
 dependencies = [
     'tree-sitter==0.22.3; python_version >= "3.9"',
-    'tree-sitter-usfm3==3.0.1-alpha.3; python_version >="3.8"',
+    'tree-sitter-usfm3==3.0.1-alpha.4; python_version >="3.8"',
     'lxml==5.2.2; python_version >= "3.5"',
     'jsonschema==4.23.0; python_version>= "3.8"'
 ]

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.0.1-alpha.4"
+version = "3.1.0"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["usfm", "parser", "grammar", "tree-sitter"]
 dependencies = [
     'tree-sitter==0.22.3; python_version >= "3.9"',
-    'tree-sitter-usfm3==3.0.1-alpha.4; python_version >="3.8"',
+    'tree-sitter-usfm3==3.1.0; python_version >="3.8"',
     'lxml==5.2.2; python_version >= "3.5"',
     'jsonschema==4.23.0; python_version>= "3.8"'
 ]

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,4 +1,4 @@
 tree-sitter==0.22.3
-tree-sitter-usfm3==3.0.1-alpha.4
+tree-sitter-usfm3==3.1.0
 lxml==5.2.2
 jsonschema==4.23.0

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,4 +1,4 @@
 tree-sitter==0.22.3
-tree-sitter-usfm3==3.0.1-alpha.3
+tree-sitter-usfm3==3.0.1-alpha.4
 lxml==5.2.2
 jsonschema==4.23.0

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.1-alpha.3",  # Required
+    version="3.0.1-alpha.4",  # Required
     python_requires=">=3.10",
     # install_requires=["tree-sitter==0.22.3",
                         # "tree-sitter-usfm3==3.0.0-beta.7",  

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.0.1-alpha.4",  # Required
+    version="3.1.0",  # Required
     python_requires=">=3.10",
     # install_requires=["tree-sitter==0.22.3",
                         # "tree-sitter-usfm3==3.0.0-beta.7",  

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -11,4 +11,4 @@ USFMParser = usfm_parser.USFMParser
 Validator = validator.Validator
 ORIGINAL_VREF = vrefs.original_vref
 
-__version__ = "3.0.1-alpha.3"
+__version__ = "3.0.1-alpha.4"

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -11,4 +11,4 @@ USFMParser = usfm_parser.USFMParser
 Validator = validator.Validator
 ORIGINAL_VREF = vrefs.original_vref
 
-__version__ = "3.0.1-alpha.4"
+__version__ = "3.1.0"

--- a/py-usfm-parser/src/usfm_grammar/__main__.py
+++ b/py-usfm-parser/src/usfm_grammar/__main__.py
@@ -7,6 +7,7 @@ import csv
 from lxml import etree
 
 from usfm_grammar import USFMParser, Filter, Format, ORIGINAL_VREF
+from usfm_grammar import __version__
 all_markers = []
 for member in Filter:
     all_markers += member.value
@@ -111,6 +112,7 @@ def main(): #pylint: disable=too-many-locals
     arg_parser.add_argument('--bookcode',
                             help='book to be exported from biblenlp to usfm format',
                             default=None)
+    arg_parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
 
 
     my_parser = handle_input_file(arg_parser)

--- a/py-usfm-parser/src/usfm_grammar/list_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/list_generator.py
@@ -20,15 +20,19 @@ class ListGenerator:
     def usj_to_list_c(self, obj):
         '''Update current chapter'''
         self.current_chapter = obj['number']
+        self.current_verse = ""
 
     def usj_to_list_v(self, obj):
         '''Update current verse'''
         self.current_verse = obj['number']
 
-    def usj_to_list(self, obj):
+    def usj_to_list(self, obj, exclude_markers=None, include_markers=None):
         '''Traverse the USJ dict and build the table in self.list'''
         if obj['type'] == "book":
             self.usj_to_list_id(obj)
+            if ((exclude_markers and "id" in exclude_markers) or \
+                (include_markers and "id" not in include_markers)):
+                return
         elif obj['type'] == "chapter":
             self.usj_to_list_c(obj)
         elif obj['type'] == "verse":
@@ -41,11 +45,20 @@ class ListGenerator:
         if 'content' in obj:
             for item in obj['content']:
                 if isinstance(item, str):
+                    if (exclude_markers and "text" in exclude_markers):
+                        item = ""
                     self.list.append(
                         [self.book, self.current_chapter, self.current_verse,
                             item, marker_type, marker_name])
                 else:
-                    self.usj_to_list(item)
+                    self.usj_to_list(item, exclude_markers, include_markers)
+        if ("content" not in obj or len(obj['content']) == 0):
+            if (not exclude_markers and not include_markers) or \
+               (exclude_markers and marker_name not in exclude_markers) or \
+               (include_markers and marker_name in include_markers):
+                self.list.append(
+                        [self.book, self.current_chapter, self.current_verse,
+                            '', marker_type, marker_name])
 
 
     def usj_to_biblenlp_format(self, obj):

--- a/py-usfm-parser/src/usfm_grammar/list_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/list_generator.py
@@ -26,7 +26,7 @@ class ListGenerator:
         '''Update current verse'''
         self.current_verse = obj['number']
 
-    def usj_to_list(self, obj, exclude_markers=None, include_markers=None):
+    def usj_to_list(self, obj, exclude_markers=None, include_markers=None): #pylint: disable=too-many-branches
         '''Traverse the USJ dict and build the table in self.list'''
         if obj['type'] == "book":
             self.usj_to_list_id(obj)
@@ -53,8 +53,11 @@ class ListGenerator:
                 else:
                     self.usj_to_list(item, exclude_markers, include_markers)
         if ("content" not in obj or len(obj['content']) == 0):
-            if (not exclude_markers and not include_markers) or \
-               (exclude_markers and marker_name not in exclude_markers) or \
+            if (not exclude_markers and not include_markers):
+                self.list.append(
+                        [self.book, self.current_chapter, self.current_verse,
+                            '', marker_type, marker_name])
+            elif (exclude_markers and marker_name not in exclude_markers) or \
                (include_markers and marker_name in include_markers):
                 self.list.append(
                         [self.book, self.current_chapter, self.current_verse,

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -105,6 +105,8 @@ class USFMParser():
             raise Exception("Missing input! Either USFM, USJ, USX or BibleNlp is to be provided.")
 
         if usfm_string is not None:
+            if not usfm_string.strip().startswith("\\"):
+                raise Exception(f"Invalid input for USFM. Expected a string with \\ markups. got: {usfm_string}")
             self.usfm = usfm_string
         elif from_usj is not None:
             usj_converter = USFMGenerator()

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -76,7 +76,7 @@ error_query = USFM_LANGUAGE.query("""(ERROR) @errors""")
 
 class USFMParser():
     """Parser class with usfmstring, syntax_tree and methods for JSON convertions"""
-    def __init__(self,              # pylint: disable=too-many-arguments
+    def __init__(self, # pylint: disable=too-many-arguments, too-many-branches
                 usfm_string:str=None,
                 from_usj:dict=None,
                 from_usx:etree.Element=None,
@@ -106,7 +106,7 @@ class USFMParser():
 
         if usfm_string is not None:
             if not usfm_string.strip().startswith("\\"):
-                raise Exception(f"Invalid input for USFM. Expected a string with \\ markups. got: {usfm_string}")
+                raise Exception("Invalid input for USFM. Expected a string with \\ markups.")
             self.usfm = usfm_string
         elif from_usj is not None:
             usj_converter = USFMGenerator()
@@ -209,11 +209,6 @@ class USFMParser():
                 f'\n\t{err_str}'+\
                 "\nUse ignore_errors=True, to generate output inspite of errors")
 
-        json_root_obj = {
-                "type": "USJ",
-                "version": "3.1",
-                "content":[]
-            }
         try:
             include_list = None
             exclude_list = None
@@ -221,7 +216,7 @@ class USFMParser():
                 include_list = include_markers+['USJ']+Filter.BCV
             if exclude_markers:
                 exclude_list = [mrkr for mrkr in exclude_markers if mrkr not in Filter.BCV]
-            
+
             usj_dict = self.to_usj(exclude_markers=exclude_list,
                                     include_markers=include_list,
                                     ignore_errors=ignore_errors,

--- a/py-usfm-parser/src/usfm_grammar/usfm_parser.py
+++ b/py-usfm-parser/src/usfm_grammar/usfm_parser.py
@@ -38,7 +38,7 @@ class Filter(list, Enum):
             ]
     STUDY_BIBLE = ['esb', 'cat']  # "sidebars-extended-contents"
     BCV = ['id','c','v']
-    TEXT = ['text-in-excluded-parent']
+    TEXT = ['text-in-excluded-parent', 'text']
     # INNER_CONTENT = ['content-in-excluded-parent']
 
 class Format(str, Enum):
@@ -215,17 +215,20 @@ class USFMParser():
                 "content":[]
             }
         try:
-            usj_generator = USJGenerator(USFM_LANGUAGE, self.usfm_bytes, json_root_obj)
-            usj_generator.node_2_usj(self.syntax_tree, json_root_obj)
-            usj_dict = usj_generator.json_root_obj
+            include_list = None
+            exclude_list = None
             if include_markers:
-                usj_dict = include_markers_in_usj(usj_dict,
-                            include_markers+['USJ']+Filter.BCV, combine_texts)
+                include_list = include_markers+['USJ']+Filter.BCV
             if exclude_markers:
-                usj_dict = exclude_markers_in_usj(usj_dict, exclude_markers, combine_texts)
+                exclude_list = [mrkr for mrkr in exclude_markers if mrkr not in Filter.BCV]
+            
+            usj_dict = self.to_usj(exclude_markers=exclude_list,
+                                    include_markers=include_list,
+                                    ignore_errors=ignore_errors,
+                                    combine_texts=combine_texts)
 
             list_generator = ListGenerator()
-            list_generator.usj_to_list(usj_dict)
+            list_generator.usj_to_list(usj_dict, exclude_markers, include_markers)
         except Exception as exe:
             message = "Unable to do the conversion. "
             if self.errors:

--- a/py-usfm-parser/tests/test_list_conversion.py
+++ b/py-usfm-parser/tests/test_list_conversion.py
@@ -76,7 +76,14 @@ def test_usj_to_biblenlp_conversion(file_path):
             assert "vref" in bible_nlp_dict
             assert len(bible_nlp_dict['text']) == len(bible_nlp_dict['vref'])
 
-
+emtpy_scritures = [
+    "../tests/mandatory/emptyV/origin.usfm",
+    "../tests/mandatory/v/origin.usfm",
+    "../tests/paratextTests/NoErrorsShort/origin.usfm",
+    "../tests/special-cases/empty-book/origin.usfm"
+]
+for path in emtpy_scritures:
+    test_files.remove(path)
 @pytest.mark.parametrize('file_path', test_files)
 @pytest.mark.timeout(30)
 def test_biblenlp_to_usfm(file_path):
@@ -85,6 +92,7 @@ def test_biblenlp_to_usfm(file_path):
     bible_nlp_dict = test_parser.to_biblenlp_format()
 
     generated_usfm = generate_USFM_from_BibleNlp(bible_nlp_dict)
+    print(generated_usfm)
 
     test_parser2 = parse_USFM_string(generated_usfm)
     assert test_parser2.errors == []

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.1-alpha.3",
+  "version": "3.0.1-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-usfm3",
-      "version": "3.0.1-alpha.3",
+      "version": "3.0.1-alpha.4",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.1-alpha.4",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-usfm3",
-      "version": "3.0.1-alpha.4",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.1-alpha.4",
+  "version": "3.1.0",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.0.1-alpha.3",
+  "version": "3.0.1-alpha.4",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/tree-sitter-usfm3/pyproject.toml
+++ b/tree-sitter-usfm3/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-usfm3"
 description = "Usfm3 grammar for tree-sitter"
-version = "3.0.1-alpha.3"
+version = "3.0.1-alpha.4"
 keywords = ["incremental", "parsing", "tree-sitter", "usfm3"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/tree-sitter-usfm3/pyproject.toml
+++ b/tree-sitter-usfm3/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-usfm3"
 description = "Usfm3 grammar for tree-sitter"
-version = "3.0.1-alpha.4"
+version = "3.1.0"
 keywords = ["incremental", "parsing", "tree-sitter", "usfm3"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/web-usfm-parser/README.md
+++ b/web-usfm-parser/README.md
@@ -23,10 +23,10 @@ function App() {
 
   useEffect(() => {
     const initParser = async () => {
-      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter.wasm");
-      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter.wasm");
+      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
+      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
 
     };
     initParser();
@@ -60,13 +60,13 @@ It can be used directly in the HTML script tag too. Please ensure its dependenci
 
 ```html
 <script type="module">
-  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/dist/bundle.mjs';
+  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/dist/bundle.mjs';
   console.log('Hello world');
   (async () => {
-  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter.wasm");
-  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.3/tree-sitter.wasm");
+  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
+  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
   const usfmParser = new USFMParser('\\id GEN\n\\c 1\n\\p\n\\v 1 In the begining..\\v 2 more text')
   const output = usfmParser.toUSJ()
   console.log({ output })

--- a/web-usfm-parser/README.md
+++ b/web-usfm-parser/README.md
@@ -23,10 +23,10 @@ function App() {
 
   useEffect(() => {
     const initParser = async () => {
-      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
-      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
+      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
+      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
 
     };
     initParser();
@@ -60,13 +60,13 @@ It can be used directly in the HTML script tag too. Please ensure its dependenci
 
 ```html
 <script type="module">
-  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/dist/bundle.mjs';
+  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/dist/bundle.mjs';
   console.log('Hello world');
   (async () => {
-  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
-  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.0.1-alpha.4/tree-sitter.wasm");
+  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
+  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
   const usfmParser = new USFMParser('\\id GEN\n\\c 1\n\\p\n\\v 1 In the begining..\\v 2 more text')
   const output = usfmParser.toUSJ()
   console.log({ output })

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar-web",
-  "version": "3.0.1-alpha.3",
+  "version": "3.0.1-alpha.4",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CS, and converts them back to USFM.",
   "type": "module",
   "module": "dist/bundle.mjs",

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar-web",
-  "version": "3.0.1-alpha.4",
+  "version": "3.1.0",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CS, and converts them back to USFM.",
   "type": "module",
   "module": "dist/bundle.mjs",

--- a/web-usfm-parser/src/listGenerator.js
+++ b/web-usfm-parser/src/listGenerator.js
@@ -6,9 +6,9 @@ class ListGenerator {
         this.currentChapter = "";
         this.currentVerse = "";
         this.list = [["Book", "Chapter", "Verse", "Text", "Type", "Marker"]];
-        this.bibleNlpFormat = { "text" : [], "vref":[] }
-        this.prevChapter = ""
-        this.prevVerse = ""
+        this.bibleNlpFormat = { "text" : [], "vref":[] };
+        this.prevChapter = "";
+        this.prevVerse = "";
     }
 
     usjToListId(obj) {
@@ -19,6 +19,7 @@ class ListGenerator {
     usjToListC(obj) {
         /* Update current chapter */
         this.currentChapter = obj.number;
+        this.currentVerse = "";
     }
 
     usjToListV(obj) {
@@ -26,10 +27,14 @@ class ListGenerator {
         this.currentVerse = obj.number;
     }
 
-    usjToList(obj) {
+    usjToList(obj, excludeMarkers=null, includeMarkers=null) {
         /* Traverse the USJ dict and build the table in this.list */
         if (obj.type === "book") {
             this.usjToListId(obj);
+            if ((excludeMarkers && excludeMarkers.includes("id")) ||
+                (includeMarkers && !includeMarkers.includes("id"))) {
+                return
+            }
         } else if (obj.type === "chapter") {
             this.usjToListC(obj);
         } else if (obj.type === "verse") {
@@ -47,10 +52,19 @@ class ListGenerator {
         if (obj.content) {
             for (let item of obj.content) {
                 if (typeof item === "string") {
+                    if (excludeMarkers && excludeMarkers.includes("text")){
+                        item = "";
+                    }
                     this.list.push([this.book, this.currentChapter, this.currentVerse, item, markerType, markerName]);
                 } else {
-                    this.usjToList(item);
+                    this.usjToList(item, excludeMarkers, includeMarkers);
                 }
+            }
+        } else {
+            if ((!excludeMarkers && !includeMarkers) ||
+                (excludeMarkers && !excludeMarkers.includes(markerName)) ||
+                (includeMarkers && includeMarkers.includes(markerName))) {
+                this.list.push([this.book, this.currentChapter, this.currentVerse, "", markerType, markerName])
             }
         }
     }

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -296,13 +296,19 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.`)
 	    }
 
 	    try {
-	    	if (includeMarkers) {
-	    		includeMarkers = [...includeMarkers, ...Filter.BCV]
+	        let excludeList = null;
+	        let includeList = null;
+	    	if (includeMarkers) { 
+	    		includeList = [...includeMarkers, ...Filter.BCV];
 	    	}
-	        const usjDict = this.toUSJ(excludeMarkers, includeMarkers, ignoreErrors, combineTexts);
+	    	if (excludeMarkers) {
+	    		excludeList = excludeMarkers.filter(item => !Filter.BCV.includes(item));
+
+	    	}
+    		const usjDict = this.toUSJ(excludeList, includeList, ignoreErrors, combineTexts);
 
 	        const listGenerator = new ListGenerator();
-	        listGenerator.usjToList(usjDict);
+	        listGenerator.usjToList(usjDict, excludeMarkers, includeMarkers);
 	    	return listGenerator.list;
 
 	    } catch (exe) {

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -51,8 +51,8 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.`)
         }
 
         if (usfmString !== null) {
-        	if (typeof usfmString !== "string" || usfmString === null) {
-				throw new Error("Invalid input for USFM. Expected a string.");
+        	if (typeof usfmString !== "string" || !usfmString.trim().startsWith("\\")) {
+				throw new Error("Invalid input for USFM. Expected a string with \\ markups.");
 			}
             this.usfm = usfmString;
         } else if(fromUsj !== null) {

--- a/web-usfm-parser/test/basic.js
+++ b/web-usfm-parser/test/basic.js
@@ -79,7 +79,7 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.` )
       const usfmParser = new USFMParser(simpleUSJ)
 
     } catch(err) {
-      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string.")
+      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string with \\ markups.")
     }
     assert.strictEqual(usfmParser, null);
   });
@@ -103,7 +103,7 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.` )
       const usfmParser = new USFMParser(simpleUSJ)
 
     } catch(err) {
-      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string.")
+      assert.strictEqual(err.message, "Invalid input for USFM. Expected a string with \\ markups.")
     }
     assert.strictEqual(usfmParser, null);
   });


### PR DESCRIPTION
This PR includes
- Implements #243 in python 
- Implements #189 
   - Checks for `\id` in the begining
   - This causes an error when empty string is passed as well
- Changes `to_list()` to accommodate #312 
   - `include_markers=Filter.BCV` lists all references without any text
   - `to_list()` without any include or exclude also contains rows for `c` and `v` markers now
   - `exclude_markers=Filter.TEXT` will now give a list of all markers used without its contents(only in `to_list()` not in `to_usj()`)  