### PR TITLE
Update pypi_publish github action

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,7 +35,7 @@ jobs:
           cd tree-sitter-usfm3
           python -m pip install build setuptools
           python -m build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: tree-sitter-usfm3/dist/*.tar.gz
 
@@ -51,7 +51,7 @@ jobs:
           cd py-usfm-parser
           python -m pip install build setuptools
           python -m build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: py-usfm-parser/dist/*.tar.gz
 
@@ -66,12 +66,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: tree-sitter-usfm3/dist/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: py-usfm-parser/dist/


### PR DESCRIPTION
Upgrades the versions of github actions due to [the deprecation](https://github.com/orgs/community/discussions/142581).
    - upload-artifact@v3 to upload-artifacts@v4
    - download-artifacts@v3 to download-artifacts@v4