### PR TITLE
3.1.0 node n web issues

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\-(?P<release>\w+)\.(?P<num>\d+))?

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CSV, and converts them back to USFM",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/es/index.mjs",
@@ -28,7 +28,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "tree-sitter": "0.21.1",
-    "tree-sitter-usfm3": "3.1.0",
+    "tree-sitter-usfm3": "3.1.1",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
   },

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -36,5 +36,8 @@
     "glob": "^11.0.0",
     "mocha": "^10.7.3",
     "parcel": "^2.12.0"
+  },
+  "peerDependencies": {
+    "xmldom": "^0.6.0"
   }
 }

--- a/node-usfm-parser/src/filters.js
+++ b/node-usfm-parser/src/filters.js
@@ -37,7 +37,7 @@ class Filter {
 
   static BCV = ['id', 'c', 'v'];
 
-  static TEXT = ['text-in-excluded-parent'];
+  static TEXT = ['text-in-excluded-parent', 'text'];
 
   static keepOnly(inputUsj, includeMarkers, combineTexts=true) {
     // let flattenedList = [].concat(...includeMarkers);

--- a/node-usfm-parser/src/listGenerator.js
+++ b/node-usfm-parser/src/listGenerator.js
@@ -49,7 +49,7 @@ class ListGenerator {
             markerType = "";
         }
 
-        if (obj.content) {
+        if (obj.content && obj.content.length>0) {
             for (let item of obj.content) {
                 if (typeof item === "string") {
                     if (excludeMarkers && excludeMarkers.includes("text")){

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["usfm", "parser", "grammar", "tree-sitter"]
 dependencies = [
     'tree-sitter==0.22.3; python_version >= "3.9"',
-    'tree-sitter-usfm3==3.1.0; python_version >="3.8"',
+    'tree-sitter-usfm3==3.1.1; python_version >="3.8"',
     'lxml==5.2.2; python_version >= "3.5"',
     'jsonschema==4.23.0; python_version>= "3.8"'
 ]

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,4 +1,4 @@
 tree-sitter==0.22.3
-tree-sitter-usfm3==3.1.0
+tree-sitter-usfm3==3.1.1
 lxml==5.2.2
 jsonschema==4.23.0

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.1.0",  # Required
+    version="3.1.1",  # Required
     python_requires=">=3.10",
     # install_requires=["tree-sitter==0.22.3",
                         # "tree-sitter-usfm3==3.0.0-beta.7",  

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -11,4 +11,4 @@ USFMParser = usfm_parser.USFMParser
 Validator = validator.Validator
 ORIGINAL_VREF = vrefs.original_vref
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-usfm3",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {
@@ -184,7 +184,7 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
@@ -471,7 +471,7 @@
       "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw=="
     },
     "npm-run-path": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/tree-sitter-usfm3/pyproject.toml
+++ b/tree-sitter-usfm3/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-usfm3"
 description = "Usfm3 grammar for tree-sitter"
-version = "3.1.0"
+version = "3.1.1"
 keywords = ["incremental", "parsing", "tree-sitter", "usfm3"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/web-usfm-parser/README.md
+++ b/web-usfm-parser/README.md
@@ -23,10 +23,10 @@ function App() {
 
   useEffect(() => {
     const initParser = async () => {
-      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
-      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
+      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
+      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
 
     };
     initParser();
@@ -60,13 +60,13 @@ It can be used directly in the HTML script tag too. Please ensure its dependenci
 
 ```html
 <script type="module">
-  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/dist/bundle.mjs';
+  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/dist/bundle.mjs';
   console.log('Hello world');
   (async () => {
-  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
-  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.0/tree-sitter.wasm");
+  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
+  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
   const usfmParser = new USFMParser('\\id GEN\n\\c 1\n\\p\n\\v 1 In the begining..\\v 2 more text')
   const output = usfmParser.toUSJ()
   console.log({ output })

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -50,5 +50,8 @@
     "ajv": "^8.17.1",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
+  },
+  "peerDependencies": {
+    "xmldom": "^0.6.0"
   }
 }

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar-web",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CS, and converts them back to USFM.",
   "type": "module",
   "module": "dist/bundle.mjs",

--- a/web-usfm-parser/src/filters.js
+++ b/web-usfm-parser/src/filters.js
@@ -37,7 +37,7 @@ class Filter {
 
   static BCV = ['id', 'c', 'v'];
 
-  static TEXT = ['text-in-excluded-parent'];
+  static TEXT = ['text-in-excluded-parent', 'text'];
 
   static keepOnly(inputUsj, includeMarkers, combineTexts=true) {
     // let flattenedList = [].concat(...includeMarkers);

--- a/web-usfm-parser/src/listGenerator.js
+++ b/web-usfm-parser/src/listGenerator.js
@@ -49,7 +49,7 @@ class ListGenerator {
             markerType = "";
         }
 
-        if (obj.content) {
+        if (obj.content && obj.content.length>0) {
             for (let item of obj.content) {
                 if (typeof item === "string") {
                     if (excludeMarkers && excludeMarkers.includes("text")){


### PR DESCRIPTION
The new features of able to list only BCV etc. in `to_list()` was not working in the released version 3.1.0 of node and web.
The web version was unpublished, but could not unpublish the node version. Instead its latest tag was moved to 3.0.0.
This PR
- Fixes the unreachable code issue that caused the above problem.
- Also fixes another issue of not updating the Filter.TEXT enum.
- Mentions xmldom as a peerDependancy as it is needed to work with the USX output.
- Bumps the version to 3.1.1 (As we cannot publish node again with 3.1.0)
