### PR TITLE
Integrate refactors into Web module

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: tree-sitter-usfm3/dist/*.tar.gz
+          overwrite: true
 
   build-py-usfm-parser:
     runs-on: ubuntu-latest
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: py-usfm-parser/dist/*.tar.gz
+          overwrite: true
 
 
   publish_to_pypi:

--- a/node-usfm-parser/src/usfmParser.js
+++ b/node-usfm-parser/src/usfmParser.js
@@ -1,374 +1,439 @@
-const Parser = require('tree-sitter');
-const assert = require('assert');
+const Parser = require("tree-sitter");
+const assert = require("assert");
 
 const {USFMGenerator} = require("./usfmGenerator");
-const {USJGenerator} = require("./usjGenerator"); 
+const {USJGenerator} = require("./usjGenerator");
 const {ListGenerator} = require("./listGenerator");
-const {USXGenerator} = require("./usxGenerator")
-const { includeMarkersInUsj, excludeMarkersInUsj, Filter } = require("./filters.js");
+const {USXGenerator} = require("./usxGenerator");
+const {
+  includeMarkersInUsj,
+  excludeMarkersInUsj,
+  Filter,
+} = require("./filters.js");
 const {ORIGINAL_VREF} = require("./utils/vrefs");
-const USFM3 = require('tree-sitter-usfm3');
-const { Query } = Parser;
+const USFM3 = require("tree-sitter-usfm3");
+const {Query} = Parser;
 
 class USFMParser {
+  constructor(
+    usfmString = null,
+    fromUsj = null,
+    fromUsx = null,
+    fromBibleNlp = null,
+    bookCode = null
+  ) {
+    this.syntaxTree = null;
+    this.errors = [];
+    this.warnings = [];
 
-	constructor(usfmString=null, fromUsj=null, fromUsx=null, fromBibleNlp=null, bookCode=null) {
-		this.syntaxTree = null;
-		this.errors = [];
-        this.warnings = [];
+    let inputsGiven = 0;
+    if (usfmString !== null) {
+      inputsGiven += 1;
+    }
+    if (fromUsj !== null) {
+      inputsGiven += 1;
+    }
+    if (fromUsx !== null) {
+      inputsGiven += 1;
+    }
+    if (fromBibleNlp !== null) {
+      inputsGiven += 1;
+    }
 
-		let inputsGiven = 0
-        if (usfmString !== null) {
-            inputsGiven += 1
+    if (inputsGiven > 1) {
+      throw new Error(`Found more than one input!
+Only one of USFM, USJ, USX or BibleNLP is supported in one object.`);
+    }
+    if (inputsGiven === 0) {
+      throw Error(
+        "Missing input! Either USFM, USJ, USX or BibleNLP is to be provided."
+      );
+    }
+
+    if (usfmString !== null) {
+      if (
+        typeof usfmString !== "string" ||
+        !usfmString.trim().startsWith("\\")
+      ) {
+        throw new Error(
+          "Invalid input for USFM. Expected a string with \\ markups."
+        );
+      }
+      this.usfm = usfmString;
+    } else if (fromUsj !== null) {
+      this.usj = fromUsj;
+      this.usfm = this.convertUSJToUSFM();
+    } else if (fromUsx !== null) {
+      this.usx = fromUsx;
+      this.usfm = this.convertUSXToUSFM();
+    } else if (fromBibleNlp !== null) {
+      this.bibleNlp = fromBibleNlp;
+      this.usfm = this.convertBibleNLPtoUSFM(bookCode);
+    }
+    this.parser = null;
+    this.initializeParser();
+
+    this.parseUSFM();
+  }
+  initializeParser() {
+    this.parser = new Parser();
+    this.parser.setLanguage(USFM3);
+    this.parserOptions = Parser.Options = {
+      bufferSize: 1024 * 1024,
+    };
+  }
+
+  toSyntaxTree() {
+    return this.syntaxTree.toString();
+  }
+
+  toUSJ(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    this.usj = this.convertUSFMToUSJ(
+      (excludeMarkers = excludeMarkers),
+      (includeMarkers = includeMarkers),
+      (ignoreErrors = ignoreErrors),
+      (combineTexts = combineTexts)
+    );
+    return this.usj;
+  }
+  toUSJ2(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    this.usj = this.convertUSFMToUSJ2(
+      (excludeMarkers = excludeMarkers),
+      (includeMarkers = includeMarkers),
+      (ignoreErrors = ignoreErrors),
+      (combineTexts = combineTexts)
+    );
+    return this.usj;
+  }
+
+  usjToUsfm(usjObject) {
+    if (
+      typeof usjObject !== "object" ||
+      usjObject === null ||
+      !usjObject.hasOwnProperty("type")
+    ) {
+      throw new Error("Invalid input for USJ. Expected USJ json object.");
+    }
+    if (!this.parser) {
+      this.initializeParser();
+    }
+    this.usj = usjObject;
+    this.usfm = this.convertUSJToUSFM();
+    return this.usfm;
+  }
+
+  parseUSFM() {
+    let tree = null;
+    try {
+      if (this.usfm.length > 25000) {
+        tree = this.parser.parse(this.usfm, null, this.parserOptions);
+      } else {
+        tree = this.parser.parse(this.usfm);
+      }
+    } catch (err) {
+      throw err;
+      // console.log("Error in parser.parse()");
+      // console.log(err.toString());
+      // console.log(this.usfm);
+    }
+    this.checkForErrors(tree);
+    this.checkforMissing(tree.rootNode);
+    // if (error) throw error;
+    this.syntaxTree = tree.rootNode;
+  }
+
+  checkForErrors(tree) {
+    const errorQuery = new Query(USFM3, "(ERROR) @errors");
+    const errors = errorQuery.captures(tree.rootNode);
+
+    if (errors.length > 0) {
+      this.errors = errors.map(
+        (error) =>
+          `At ${error.node.startPosition.row}:${
+            error.node.startPosition.column
+          }, Error: ${this.usfm.substring(
+            error.node.startIndex,
+            error.node.endIndex
+          )}`
+      );
+      return new Error(`Errors found in USFM: ${this.errors.join(", ")}`);
+    }
+  }
+
+  checkforMissing(node) {
+    for (let n of node.children) {
+      if (n.isMissing) {
+        this.errors.push(
+          `At ${n.startPosition.row + 1}:${
+            n.startPosition.column
+          }, Error: Missing ${n.type}`
+        );
+      }
+      this.checkforMissing(n);
+    }
+  }
+
+  convertUSJToUSFM() {
+    const outputUSFM = new USFMGenerator().usjToUsfm(this.usj); // Simulated conversion
+    return outputUSFM;
+  }
+
+  convertUSXToUSFM() {
+    try {
+      assert(
+        1 <= this.usx.nodeType && this.usx.nodeType <= 12,
+        "Input must be an instance of xmldom Document or Element"
+      );
+      if (this.usx.tagName !== "usx") {
+        assert(
+          this.usx.getElementsByTagName("usx").length === 1,
+          "Expects a <usx> node. Refer docs: https://docs.usfm.bible/usfm/3.1/syntax.html#_usx_usfm_xml"
+        );
+
+        this.usx = this.usx.getElementsByTagName("usx")[0];
+      }
+      // assert(this.usx.childNodes[0].tagName === 'book', "<book> expected as first element in <usx>")
+    } catch (err) {
+      throw new Error("USX not in expected format. " + err.message);
+    }
+    try {
+      const usfmGen = new USFMGenerator();
+      usfmGen.usxToUsfm(this.usx);
+      // console.log(usfmGen.usfmString)
+      return usfmGen.usfmString;
+    } catch (err) {
+      let message = "Unable to do the conversion from USX to USFM. ";
+      throw new Error(message, {cause: err});
+    }
+  }
+
+  convertBibleNLPtoUSFM(bookCode) {
+    try {
+      assert(this.bibleNlp["vref"], "Should have 'vref' key");
+      assert(this.bibleNlp["text"], "Should have 'text' key");
+      assert(
+        Array.isArray(this.bibleNlp["vref"]),
+        "'vref' should contain an array of references."
+      );
+      assert(
+        Array.isArray(this.bibleNlp["text"]),
+        "'text' should contain an array of strings."
+      );
+      let vrefs = this.bibleNlp.vref;
+      if (
+        [31170, 23213].includes(this.bibleNlp.text.length) &&
+        vrefs.length === 41899
+      ) {
+        vrefs = vrefs.slice(0, this.bibleNlp.text.length);
+        this.bibleNlp.vref = vrefs;
+      }
+      if (bookCode !== null) {
+        bookCode = bookCode.trim().toUpperCase();
+        vrefs = this.bibleNlp.vref.filter((ref) =>
+          ref.trim().toUpperCase().startsWith(bookCode)
+        );
+      }
+
+      if (vrefs.length !== this.bibleNlp.text.length) {
+        if (
+          this.bibleNlp.vref.length === this.bibleNlp.text.length &&
+          bookCode !== null
+        ) {
+          let texts = this.bibleNlp.text.filter((txt, index) =>
+            this.bibleNlp.vref[index].trim().toUpperCase().startsWith(bookCode)
+          );
+          this.bibleNlp.text = texts;
         }
-        if (fromUsj !== null) {
-            inputsGiven += 1
+        if (vrefs.length !== this.bibleNlp.text.length) {
+          throw new Error(
+            `Mismatch in lengths of vref and text lists. ` +
+              `Specify a bookCode or check for versification differences. ` +
+              `${vrefs.length} != ${this.bibleNlp.text.length}`
+          );
         }
-        if (fromUsx !== null) {
-            inputsGiven += 1
-        }
-        if (fromBibleNlp !== null) {
-            inputsGiven += 1
-        }
+      }
+      this.bibleNlp.vref = vrefs;
+    } catch (err) {
+      throw new Error("BibleNLP object not in expected format. " + err.message);
+    }
+    try {
+      const usfmGen = new USFMGenerator();
+      usfmGen.bibleNlptoUsfm(this.bibleNlp);
+      this.warnings = usfmGen.warnings;
+      return usfmGen.usfmString;
+    } catch (err) {
+      let message = "Unable to do the conversion from BibleNLP to USFM. ";
+      throw new Error(message, {cause: err});
+    }
+  }
 
-        if (inputsGiven > 1) {
-            throw new  Error(`Found more than one input!
-Only one of USFM, USJ, USX or BibleNLP is supported in one object.`)
-        }
-        if (inputsGiven === 0) {
-            throw Error("Missing input! Either USFM, USJ, USX or BibleNLP is to be provided.")
-        }
+  convertUSFMToUSJ(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors = true, as third parameter of toUSJ(), to generate output despite errors.`
+      );
+    }
 
-        if (usfmString !== null) {
-        	if (typeof usfmString !== "string" || !usfmString.trim().startsWith("\\")) {
-				throw new Error("Invalid input for USFM. Expected a string with \\ markups.");
-			}
-            this.usfm = usfmString;
-        } else if(fromUsj !== null) {
-        	this.usj = fromUsj;
-        	this.usfm = this.convertUSJToUSFM()
-        } else if (fromUsx !== null) {
-        	this.usx = fromUsx;
-        	this.usfm = this.convertUSXToUSFM()
-        } else if (fromBibleNlp !== null) {
-        	this.bibleNlp = fromBibleNlp;
-        	this.usfm = this.convertBibleNLPtoUSFM(bookCode)
-        }
-		this.parser = null;
-		this.initializeParser();
+    let outputUSJ;
+    try {
+      let usjGenerator = new USJGenerator(USFM3, this.usfm);
 
-        this.parseUSFM();
+      usjGenerator.nodeToUSJ(this.syntaxTree, usjGenerator.jsonRootObj);
+      outputUSJ = usjGenerator.jsonRootObj;
+    } catch (err) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      } else {
+        message = err.message;
+      }
+      return {error: message};
+    }
 
-	}
-	initializeParser() {
-		this.parser = new Parser();
-		this.parser.setLanguage(USFM3);
-		this.parserOptions = Parser.Options = {
-						      bufferSize: 1024 * 1024,
-						    };
-	}
+    if (includeMarkers) {
+      outputUSJ = Filter.keepOnly(
+        outputUSJ,
+        [...includeMarkers, "USJ"],
+        combineTexts
+      );
+    }
+    if (excludeMarkers) {
+      outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
+    }
 
-	toSyntaxTree() {
-		return this.syntaxTree.toString();
-	}
+    return outputUSJ;
+  }
 
-	toUSJ(excludeMarkers = null,
-		includeMarkers = null,
-		ignoreErrors = false,
-		combineTexts = true,) {
-		this.usj = this.convertUSFMToUSJ(excludeMarkers = excludeMarkers,
-								includeMarkers = includeMarkers,
-								ignoreErrors = ignoreErrors,
-								combineTexts = combineTexts,);
-		return this.usj;
-	}
-
-	usjToUsfm(usjObject) {
-		if (typeof usjObject !== "object" || usjObject === null || (!usjObject.hasOwnProperty('type'))) {
-			throw new Error("Invalid input for USJ. Expected USJ json object.");
-		}
-		if (!this.parser) {
-			this.initializeParser();
-		}
-		this.usj = usjObject;
-		this.usfm = this.convertUSJToUSFM();
-		return this.usfm;
-	}
-
-	parseUSFM() {
-		let tree = null;
-		try {
-			if (this.usfm.length > 25000) {
-				tree = this.parser.parse(this.usfm, null, this.parserOptions);
-			}
-			else {
-				tree = this.parser.parse(this.usfm);
-			}
-		} catch (err) {
-			throw err;
-			// console.log("Error in parser.parse()");
-			// console.log(err.toString());
-			// console.log(this.usfm);
-		}
-		this.checkForErrors(tree);
-		this.checkforMissing(tree.rootNode);
-		// if (error) throw error;
-		this.syntaxTree = tree.rootNode;
-	}
-
-
-	checkForErrors(tree) {
-		const errorQuery = new Query(USFM3, "(ERROR) @errors");
-		const errors = errorQuery.captures(tree.rootNode);
-
-		if (errors.length > 0) {
-			this.errors = errors.map(
-				(error) =>
-					`At ${error.node.startPosition.row}:${error.node.startPosition.column}, Error: ${this.usfm.substring(error.node.startIndex, error.node.endIndex)}`,
-			);
-			return new Error(`Errors found in USFM: ${this.errors.join(", ")}`);
-		}
-	}
-
-	checkforMissing(node) {
-	   for (let n of node.children) {
-	        if (n.isMissing){
-	        		this.errors.push(
-						`At ${n.startPosition.row+1}:${n.startPosition.column}, Error: Missing ${n.type}`) 
-	        } 
-	        this.checkforMissing(n);
-	    }
-	}
-	
-
-	convertUSJToUSFM() {
-		const outputUSFM = new USFMGenerator().usjToUsfm(this.usj); // Simulated conversion
-		return outputUSFM;
-	}
-
-	convertUSXToUSFM() {
-		try {
-			assert(1 <= this.usx.nodeType && this.usx.nodeType <= 12 ,
-		        'Input must be an instance of xmldom Document or Element'
-		    );
-			if (this.usx.tagName !== "usx") {
-				assert(this.usx.getElementsByTagName('usx').length === 1,
-					'Expects a <usx> node. Refer docs: https://docs.usfm.bible/usfm/3.1/syntax.html#_usx_usfm_xml');
-
-				this.usx = this.usx.getElementsByTagName('usx')[0]
-			}
-			// assert(this.usx.childNodes[0].tagName === 'book', "<book> expected as first element in <usx>")
-
-		} catch(err) {
-			throw new Error("USX not in expected format. "+err.message)
-		}
-		try {
-			const usfmGen = new USFMGenerator()
-			usfmGen.usxToUsfm(this.usx);
-			// console.log(usfmGen.usfmString)
-			return usfmGen.usfmString;
-		} catch(err) {
-	        let message = "Unable to do the conversion from USX to USFM. ";
-	        throw new Error(message, { cause: err });
-		}
-	}
-
-	convertBibleNLPtoUSFM(bookCode) {
-		try {
-			assert(this.bibleNlp['vref'],
-				"Should have 'vref' key");
-			assert(this.bibleNlp['text'],
-				"Should have 'text' key");
-			assert(Array.isArray(this.bibleNlp['vref']),
-				"'vref' should contain an array of references.");
-			assert(Array.isArray(this.bibleNlp['text']),
-				"'text' should contain an array of strings.")
-			let vrefs = this.bibleNlp.vref;
-			if ([31170, 23213].includes(this.bibleNlp.text.length) && vrefs.length === 41899) {
-			    vrefs = vrefs.slice(0, this.bibleNlp.text.length);
-			    this.bibleNlp.vref =vrefs;
-			}
-			if (bookCode !== null) {
-				bookCode = bookCode.trim().toUpperCase();
-			    vrefs = this.bibleNlp.vref.filter(ref => ref.trim().toUpperCase().startsWith(bookCode));
-			}
-
-			if (vrefs.length !== this.bibleNlp.text.length) {
-			    if (this.bibleNlp.vref.length === this.bibleNlp.text.length && bookCode !== null) {
-			        let texts = this.bibleNlp.text.filter((txt, index) => 
-			            this.bibleNlp.vref[index].trim().toUpperCase().startsWith(bookCode)
-			        );
-			        this.bibleNlp.text = texts;
-			    }
-			    if (vrefs.length !== this.bibleNlp.text.length) {
-			        throw new Error(`Mismatch in lengths of vref and text lists. ` +
-			                        `Specify a bookCode or check for versification differences. ` +
-			                        `${vrefs.length} != ${this.bibleNlp.text.length}`);
-			    }
-			}
-			this.bibleNlp.vref = vrefs;
-
-		} catch(err) {
-			throw new Error("BibleNLP object not in expected format. "+ err.message)
-		}
-		try {
-			const usfmGen = new USFMGenerator();
-			usfmGen.bibleNlptoUsfm(this.bibleNlp);
-			this.warnings = usfmGen.warnings;
-			return usfmGen.usfmString;
-		} catch(err) {
-			let message = "Unable to do the conversion from BibleNLP to USFM. ";
-			throw new Error(message, {cause: err});
-		}
-	}
-
-	convertUSFMToUSJ(
-		excludeMarkers = null,
-		includeMarkers = null,
-		ignoreErrors = false,
-		combineTexts = true,) {
-		if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-			throw new Error(
-				`Errors present:\n\t${errorString}\nUse ignoreErrors = true, as third parameter of toUSJ(), to generate output despite errors.`,
-			);
-		}
-
-		let outputUSJ;
-		try {
-			let usjGenerator = new USJGenerator(
-				USFM3,
-				this.usfm
-			);
-
-			usjGenerator.nodeToUSJ(this.syntaxTree, usjGenerator.jsonRootObj);
-			outputUSJ = usjGenerator.jsonRootObj;
-		} catch (err) {
-			let message = "Unable to do the conversion. ";
-			if (this.errors) {
-				let errorString = this.errors.join("\n\t");
-				message += `Could be due to an error in the USFM\n\t${errorString}`;
-			}
-			else {
-				message = err.message;
-			}
-			return {error: message};
-		}
-
-		if (includeMarkers) {
-			outputUSJ = Filter.keepOnly(outputUSJ, [...includeMarkers, 'USJ'], combineTexts);
-		}
-		if (excludeMarkers) {
-			outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
-		}
-
-		return outputUSJ;
-	}
-
-	toList(
-	    excludeMarkers = null,
-	    includeMarkers = null,
-	    ignoreErrors = false,
-	    combineTexts = true
-	) {
-	    /* Uses the toJSON function and converts JSON to CSV
+  toList(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    /* Uses the toJSON function and converts JSON to CSV
 	       To be re-implemented to work with the flat JSON schema */
 
-	    if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
-	    }
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`
+      );
+    }
 
-	    try {
-	        let excludeList = null;
-	        let includeList = null;
-	    	if (includeMarkers) { 
-	    		includeList = [...includeMarkers, ...Filter.BCV];
-	    	}
-	    	if (excludeMarkers) {
-	    		excludeList = excludeMarkers.filter(item => !Filter.BCV.includes(item));
+    try {
+      let excludeList = null;
+      let includeList = null;
+      if (includeMarkers) {
+        includeList = [...includeMarkers, ...Filter.BCV];
+      }
+      if (excludeMarkers) {
+        excludeList = excludeMarkers.filter(
+          (item) => !Filter.BCV.includes(item)
+        );
+      }
+      const usjDict = this.toUSJ(
+        excludeList,
+        includeList,
+        ignoreErrors,
+        combineTexts
+      );
 
-	    	}
-    		const usjDict = this.toUSJ(excludeList, includeList, ignoreErrors, combineTexts);
+      const listGenerator = new ListGenerator();
+      listGenerator.usjToList(usjDict, excludeMarkers, includeMarkers);
+      return listGenerator.list;
+    } catch (exe) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors.length > 0) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      }
+      throw new Error(message, {cause: exe});
+    }
+  }
 
-	        const listGenerator = new ListGenerator();
-	        listGenerator.usjToList(usjDict, excludeMarkers, includeMarkers);
-	    	return listGenerator.list;
-
-	    } catch (exe) {
-	        let message = "Unable to do the conversion. ";
-	        if (this.errors.length > 0) {
-				let errorString = this.errors.join("\n\t");
-	            message += `Could be due to an error in the USFM\n\t${errorString}`;
-	        }
-	        throw new Error(message, { cause: exe });
-	    }
-
-	}
-
-	toBibleNlpFormat(ignoreErrors = false) {
-	    /* Uses the toUSJ function with only BVC and text.
+  toBibleNlpFormat(ignoreErrors = false) {
+    /* Uses the toUSJ function with only BVC and text.
 	       Then the JSOn is converted to list of verse texts and vrefs*/
 
-	    if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
-	    }
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`
+      );
+    }
 
-	    try {
-	        const usjDict = this.toUSJ(null, [...Filter.BCV, ...Filter.TEXT], ignoreErrors, true);
-	        const listGenerator = new ListGenerator();
-	        listGenerator.usjToBibleNlpFormat(usjDict);
-	    	return listGenerator.bibleNlpFormat;
+    try {
+      const usjDict = this.toUSJ(
+        null,
+        [...Filter.BCV, ...Filter.TEXT],
+        ignoreErrors,
+        true
+      );
+      const listGenerator = new ListGenerator();
+      listGenerator.usjToBibleNlpFormat(usjDict);
+      return listGenerator.bibleNlpFormat;
+    } catch (exe) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors.length > 0) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      }
+      throw new Error(message, {cause: exe});
+    }
+  }
 
-	    } catch (exe) {
-	        let message = "Unable to do the conversion. ";
-	        if (this.errors.length > 0) {
-				let errorString = this.errors.join("\n\t");
-	            message += `Could be due to an error in the USFM\n\t${errorString}`;
-	        }
-	        throw new Error(message, { cause: exe });
-	    }
+  toUSX(ignoreErrors = false) {
+    /* Convert the syntax_tree to the XML format (USX) */
 
-	}
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`
+      );
+    }
+    let xmlContent = null;
 
-	toUSX(ignoreErrors = false) {
-	    /* Convert the syntax_tree to the XML format (USX) */
+    try {
+      // Initialize the USX generator (assuming the constructor is already implemented in JS)
+      const usxGenerator = new USXGenerator(USFM3, this.usfm);
 
-	    if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
-	    }
-	    let xmlContent = null;
+      // Process the syntax tree and convert to USX format
+      usxGenerator.node2Usx(this.syntaxTree, usxGenerator.xmlRootNode);
 
-	    try {
-	        // Initialize the USX generator (assuming the constructor is already implemented in JS)
-	        const usxGenerator = new USXGenerator(USFM3,
-													this.usfm);
-	        
-	        // Process the syntax tree and convert to USX format
-	        usxGenerator.node2Usx(this.syntaxTree, usxGenerator.xmlRootNode);
+      // xmlContent = usxSerializer.serializeToString(usxGenerator.xmlRootNode);
+      xmlContent = usxGenerator.xmlRootNode;
+    } catch (exe) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors.length > 0) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      }
+      throw new Error(message, {cause: exe});
+    }
 
-	        // xmlContent = usxSerializer.serializeToString(usxGenerator.xmlRootNode);
-	        xmlContent = usxGenerator.xmlRootNode;
-	    } catch (exe) {
-	        let message = "Unable to do the conversion. ";
-	        if (this.errors.length > 0) {
-				let errorString = this.errors.join("\n\t");
-	            message += `Could be due to an error in the USFM\n\t${errorString}`;
-	        }
-	        throw new Error(message, { cause: exe });
-	    }
-
-	    // Return the generated XML structure (in JSON format)
-	    return xmlContent;
-	}
-
-
+    // Return the generated XML structure (in JSON format)
+    return xmlContent;
+  }
 }
-
 
 exports.USFMParser = USFMParser;
 exports.Filter = Filter;
-exports.ORIGINAL_VREF = ORIGINAL_VREF
+exports.ORIGINAL_VREF = ORIGINAL_VREF;
 // exports.Format = Format;

--- a/web-usfm-parser/bench.js
+++ b/web-usfm-parser/bench.js
@@ -31,6 +31,10 @@ import {run, bench, boxplot, summary} from "mitata";
     const txt = await readFile(path, "utf-8"); // Specify encoding
     const len = txt.length;
     const parser = new USFMParser(txt);
+    // See how expensive just traversing tree is; (not very)
+    bench(`walkTree-${fileName}-len-${len}`, () => parser.walkTheTree()).gc(
+      "inner"
+    );
     boxplot(() => {
       summary(() => {
         bench(`CURRENT-${fileName}-len-${len}`, () =>
@@ -44,7 +48,7 @@ import {run, bench, boxplot, summary} from "mitata";
   }
 
   await run({
-    format: "markdown",
+    format: "json",
   });
 })();
 /* 

--- a/web-usfm-parser/bench.js
+++ b/web-usfm-parser/bench.js
@@ -1,0 +1,64 @@
+import {USFMParser} from "./src/index.js";
+import {readFile} from "fs/promises";
+import {run, bench, boxplot, summary} from "mitata";
+
+(async () => {
+  await USFMParser.init("tree-sitter-usfm.wasm", "tree-sitter.wasm");
+
+  // these are representative test cases showing jumps in size for performance measure as file sizes increase
+  const pathsToBench = [
+    "../tests/basic/minimal/origin.usfm",
+    "../tests/special-cases/figure_with_quotes_in_desc/origin.usfm",
+    "../tests/advanced/header/origin.usfm",
+    // // about 1k chars
+    "../tests/specExamples/extended/sidebars/origin.usfm",
+    "../tests/usfmjsTests/heb1-1_multi_alignment/origin.usfm",
+    "../tests/usfmjsTests/acts_1_4.aligned/origin.usfm",
+    // // 40% of next, or 1.5% of longest
+    "../tests/usfmjsTests/usfmIntroTest/origin.usfm",
+    // 4% of longest, or 1/3 of next
+    "../tests/samples-from-wild/tamil-IRV1/origin.usfm",
+    "../tests/samples-from-wild/WEB3/origin.usfm",
+    // about 30% of the longest case
+    "../tests/samples-from-wild/ta2il-IRV1/origin.usfm",
+    // about 60% of the longest case
+    "../tests/special-cases/IRV3/origin.usfm",
+    // the longest test case
+    "../tests/special-cases/IRV4/origin.usfm",
+  ];
+  for await (const path of pathsToBench) {
+    const fileName = path.split("/").at(-2);
+    const txt = await readFile(path, "utf-8"); // Specify encoding
+    const len = txt.length;
+    const parser = new USFMParser(txt);
+    boxplot(() => {
+      summary(() => {
+        bench(`CURRENT-${fileName}-len-${len}`, () =>
+          parser.toUSJ(null, null, true)
+        ).gc("inner");
+        bench(`NEW-${fileName}-len-${len}`, () =>
+          parser.toUSJ2(null, null, true)
+        ).gc("inner");
+      });
+    });
+  }
+
+  await run({
+    format: "markdown",
+  });
+})();
+/* 
+On mac, (zsh mac stat is different than bash a bit), to see lenght of usfm files for testing: 
+
+find ../tests -type f -name "*.usfm" -print0 | while IFS= read -r -d '' file; do
+ size=$(stat -f "%z" "$file")
+ echo "$size $file"
+done | sort -n
+
+
+non bsd/mac:
+find . -type f -name "*.usfm" | while read -r file; do
+  echo -n "$file: "
+  stat --format="%s" "$file"
+done
+*/

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "glob": "^11.0.0",
+    "mitata": "^1.0.34",
     "mocha": "^10.7.3",
     "parcel": "latest",
     "path-browserify": "^1.0.1",

--- a/web-usfm-parser/pnpm-lock.yaml
+++ b/web-usfm-parser/pnpm-lock.yaml
@@ -1,0 +1,3001 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      xmldom:
+        specifier: ^0.6.0
+        version: 0.6.0
+      xpath:
+        specifier: ^0.0.34
+        version: 0.0.34
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.25.2
+        version: 7.27.1
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.2
+      mitata:
+        specifier: ^1.0.34
+        version: 1.0.34
+      mocha:
+        specifier: ^10.7.3
+        version: 10.8.2
+      parcel:
+        specifier: latest
+        version: 2.14.4(@swc/helpers@0.5.17)
+      path-browserify:
+        specifier: ^1.0.1
+        version: 1.0.1
+      process:
+        specifier: ^0.11.10
+        version: 0.11.10
+      web-tree-sitter:
+        specifier: ^0.22.6
+        version: 0.22.6
+      xml2js:
+        specifier: ^0.6.2
+        version: 0.6.2
+
+packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.27.1':
+    resolution: {integrity: sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.27.1':
+    resolution: {integrity: sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.1':
+    resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.1':
+    resolution: {integrity: sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.27.1':
+    resolution: {integrity: sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.27.1':
+    resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.1':
+    resolution: {integrity: sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.27.1':
+    resolution: {integrity: sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.1':
+    resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/gen-mapping@0.3.8':
+    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@lezer/common@1.2.3':
+    resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
+
+  '@lezer/lr@1.4.2':
+    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+
+  '@lmdb/lmdb-darwin-arm64@2.8.5':
+    resolution: {integrity: sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@lmdb/lmdb-darwin-x64@2.8.5':
+    resolution: {integrity: sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@lmdb/lmdb-linux-arm64@2.8.5':
+    resolution: {integrity: sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@lmdb/lmdb-linux-arm@2.8.5':
+    resolution: {integrity: sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@lmdb/lmdb-linux-x64@2.8.5':
+    resolution: {integrity: sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@lmdb/lmdb-win32-x64@2.8.5':
+    resolution: {integrity: sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@mischnic/json-sourcemap@0.1.1':
+    resolution: {integrity: sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w==}
+    engines: {node: '>=12.0.0'}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/bundler-default@2.14.4':
+    resolution: {integrity: sha512-JVqi5Sb7wv2KCTJFAAjHbnl6KC61jKNVYw/GtZm5s/Wxqvxx2tcp93rmRoBFo9X3gSgkg8jp4HkNAUHTxnsPnQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/cache@2.14.4':
+    resolution: {integrity: sha512-CTTMySgNSgcSwbNWL4gODU1h9hMjBRyiC8/gcKDFqzw0wC/T+ZwX7wc5zNc/S9aJRTmmgvndcYKoVlds7YV2sg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/codeframe@2.14.4':
+    resolution: {integrity: sha512-fRKkmFGnQIa/X+Kr8csTWjOwRRh2JfJfTpNS8JhbjBSWvOoKsDG9T2U5Ky8akIG7c9WDGwB3ngONauI1vtaInA==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/compressor-raw@2.14.4':
+    resolution: {integrity: sha512-wYRdokznP1iI3n6M6leQ0nI65tCIWhZaD0vW3G3qodDFi+qsdpvZymCpNUkh6AYkFFr3Lur+r/+xkWDoqNoMWA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/config-default@2.14.4':
+    resolution: {integrity: sha512-bHtr8yT2IZDv5w44/VKoNz07goidO99c6hsp9s0hjSVC1G6krdE+nriryPVfUFbw044LeQThSvA8EwTas72QZg==}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/core@2.14.4':
+    resolution: {integrity: sha512-dtUMmPDXd7CRAWwMlOc6jh6yLRL4wMi/vNMNdX9J/fafCLFgFBmPqWBhQ9tlX015Q8DEcIRWYPumHIn5dzqEbg==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/diagnostic@2.14.4':
+    resolution: {integrity: sha512-+pElcMMlTnpEIm9MrrSEOh38ylKYYdTYMgv2iZQU7799yzD9sSac9dkGSbbKGDYWhALCuzWQOgdaGG9ExJZw6w==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/error-overlay@2.14.4':
+    resolution: {integrity: sha512-GZ6Z1XO/VYqIFNwa3iAYWX7Pskwd+xw9tPw9kjF7tG8wdL9VipkcILJ4APj/G5CKw8XrXH/6NsC7HndNbR7EqA==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/events@2.14.4':
+    resolution: {integrity: sha512-QzZr291JuENw7BsehKc3z29ukLMApPdjRFcOYXFuMWaHkpC7lzFK/KAY4Mi9HCa3aQe90zCcuxZg+bBsNF9XxQ==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/feature-flags@2.14.4':
+    resolution: {integrity: sha512-T2HE+lOmlU6PZOUnuXn6UZPXV4higCPgF2c2YXhrzTlSFcLMiAXATyzrylbYY/i/WjiYAlqvmEcaBX5fSaW95g==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/fs@2.14.4':
+    resolution: {integrity: sha512-SQbuW6v1URv871FVj23HoC8+UUwpgkQ7iWmG7EITpp6AV42ojRr/jZ93hLjzkQQfYlRI64jUExn6AQAZDN3bqQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/graph@3.4.4':
+    resolution: {integrity: sha512-AIbJ8d8aCPcKAkqc45LENjAMIrp8nRGlmky5LyY5244qqnR1B+tsvU47XoGymM3OaXLdVjv8knJ4K0ci9/l/4w==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/logger@2.14.4':
+    resolution: {integrity: sha512-uqSGeCqraWpbe8gqbb1k9ePrlzdKoOwkdQPcRIv8TTTWZfCt6Qcl08w8didO4iAOz4H5C4Ng82wbVO/ieaMoKg==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/markdown-ansi@2.14.4':
+    resolution: {integrity: sha512-B4787HHXHi0wcuYbV4qBibws/yaX4RXoNel5xWdwzn1ZFmeLAXluNjMO2Q6FmII/Lej9OIQEaTppl7/DxJGifg==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/namer-default@2.14.4':
+    resolution: {integrity: sha512-3FvZhkRgYlipj0NGRmw/rZ9ZiuM+a9ZcNW/MHRpytiNNBgcGCpR00XKhhvn0O5//MH13nLpiQXUf+J279CuN2A==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/node-resolver-core@3.5.4':
+    resolution: {integrity: sha512-KmmsVD8Ym+19DIbe0Y2SUbdcB+iUfgstR4dBpaogV36DlxV4d0uiia4GCpOO3kG9zlRYMVsfZEwy/NNZHELx3w==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/optimizer-css@2.14.4':
+    resolution: {integrity: sha512-5rwwnsP8pnTqis5fs2YyNUvke6YprWlU8Y9pD55hK1Y1MbYmvCqaIyQv9lcpHJQiqrwsZ2pl5B3Ph5buDSQehQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/optimizer-htmlnano@2.14.4':
+    resolution: {integrity: sha512-hLVaN7ResQcgKRo9uDm7oddC4DwR7qoTFsYn4Ftj8qGbgqB2nRpCCK0R66PA/9U98LyTOlAl1J6TEvxWR+IlKw==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/optimizer-image@2.14.4':
+    resolution: {integrity: sha512-F5xw6ayFWOxu2XP5MI8g9khOCKNkVj4nGoXrBcgLoCKW4o07buCUKY4Sy04P3u7Leip6TOk7qpt3Q1179h6KTQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/optimizer-svgo@2.14.4':
+    resolution: {integrity: sha512-bjZ2VHhzclBQ99SC2ZXsFKJ6zi0hXTPbGdaVblMu0iheeXcATdoNzey0eizaoSmLe9IyFJoN6gvnLdQqGfZLZg==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/optimizer-swc@2.14.4':
+    resolution: {integrity: sha512-7+p5ILEj2S02Rs6YzwF74g0kpAZzF9idDP9zjLVZWo9JYvoRvH0LW90bI7yKXWpKB8QOtwziqgWkcgItSIWBnA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/package-manager@2.14.4':
+    resolution: {integrity: sha512-chF2rBmLtLPZe0qtbqJtq6hNGCRu0+1wFs2j5sqxr1ZttvvhRpATu/7pD+gKTFmfL7iJkOpGTU485SYmyO1xjg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/packager-css@2.14.4':
+    resolution: {integrity: sha512-AvJhE1AQ4OcuOUtKoifhE1Y8KgYitzKMvmgsgQlwySdrkk6dz+XGHfZ9goTzIUaz9xZzwbJH7h/pvaIP8jQ9yQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/packager-html@2.14.4':
+    resolution: {integrity: sha512-rsYz3NDaKRCuQOAWGc3eYJ2GHesm62iRCQTMGlZ7Oplp748vu2c1Uee/mP43WlslvDxHtV7rzVNyo88MS6sc5w==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/packager-js@2.14.4':
+    resolution: {integrity: sha512-Fz98TzYFcd9xCj6jqMtyd7c3n65GRmuoG7u0S/2g4sJrR5Zen70n1zlBGX7mEoOvB5lKRijzoNqBtB+7bWqS5A==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/packager-raw@2.14.4':
+    resolution: {integrity: sha512-7yDcPGsSSz4WiCWj2KoC2pNBXNislulI1RXaWyBAMzQhevQ+9D2ga/ZPgpcNjcWr8Y1tRb3QITETkTmZVHmPXQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/packager-svg@2.14.4':
+    resolution: {integrity: sha512-ja5P9PXp+v/mh+UXUXdQ1O35yr2kRqdRlytYrzmAaeILuS1ko2n3ZJoeUYYprYOh/UmLmkgbXh/DyzrhEH7TZw==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/packager-wasm@2.14.4':
+    resolution: {integrity: sha512-sgGCitPjl80Ku+xZIu3wCIAjOYXVEGJ00uXeexR8hgMx/PMhiHXLWUG8eLYAvxXx/CcLmHDOEBNrl6G3JxsP9g==}
+    engines: {node: '>=16.0.0', parcel: ^2.14.4}
+
+  '@parcel/plugin@2.14.4':
+    resolution: {integrity: sha512-EcehbthkBtQ9S2jWAzIiSlodbIMZ0bSsN3PC1q9jVaCM16ueObjZohKkzMjzR6Qot91qL0EJoMLzuNvtryvpHA==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/profiler@2.14.4':
+    resolution: {integrity: sha512-oZAdCDW3bYRpBOuL4coq4OQDN6HXADaSd4X8xJCeGsEsbVfJt0Qg5RgxdWC1L86mukyZMQ9ZrQUpC8aU9CAmFg==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/reporter-cli@2.14.4':
+    resolution: {integrity: sha512-KgBXBiwGb9hqf3A6vw6eIqX1uYaMRjSqYXUUybGTOxonc+yB6J5q+skv1Wuty6IYuBfjNlV/zdvgggVZMl0ZxA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/reporter-dev-server@2.14.4':
+    resolution: {integrity: sha512-Ezg24vHftV0El0tWcxnsGAxwSdNTMs9M+l9Nbm1k4rydx1lCoKBAhpa2Icv8vKZY8K075giww8TOkjk6zVkAmQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/reporter-tracer@2.14.4':
+    resolution: {integrity: sha512-EN+rzdEnoMuC5qbYIcuP6v1vTb/dDPrrnIEtDFEsSyuBuDfQevtOech8oHzjGEBOlC8svm+OzW/wIj2L2rmF2A==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/resolver-default@2.14.4':
+    resolution: {integrity: sha512-s4XKnfScF/cwqGyYG/sB4WpktIJ55dvpu64ZiglHkkPvY5wT4p7A61mTIp6ck0ZPYmeG/zfd+P0B3qPpNF5mUw==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/runtime-browser-hmr@2.14.4':
+    resolution: {integrity: sha512-7o3XHOkuNy2jUH8xdKJSzIfatdAqvr/PHg9vQN0Cz4r80XCXDh1ovfz/x0Q9gpBv+LMBs+ufZ4tP+RfgJ/jKpQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/runtime-js@2.14.4':
+    resolution: {integrity: sha512-F9RvDELU/0fyV2/rHkjpPcLeKF/ZU3gnHIQnkh2Q5/41XhymyNAvMmYGPM6VpbOAnDlYeVjwfyJ41x8FOL6u4Q==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/runtime-rsc@2.14.4':
+    resolution: {integrity: sha512-FXoO1GWvC/yQOUYX+0rTUQVku91DSJnjegqJaiJSUOEGeJWF9mBmY/3QDkksvhwB25vJkLYsu/M5Fx83OA2u6w==}
+    engines: {node: '>= 12.0.0', parcel: ^2.14.4}
+
+  '@parcel/runtime-service-worker@2.14.4':
+    resolution: {integrity: sha512-6+vz2DYP9tK+GHRPwW/qfUNvGOHvFpsN/Thk+tSIZ+PHT1DTWfpf02eo7fzpImdZAzllSz3m1IXgrOH00LdOKA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/rust@2.14.4':
+    resolution: {integrity: sha512-Ti+ZVr8mMTgrSA7UHcFXxG98anD0C8dGzYfP1+DTgxkcU16nywTv5F/VsPqpV2qiDWrHbm06CEWQbOrowjzvVw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      napi-wasm: ^1.1.2
+    peerDependenciesMeta:
+      napi-wasm:
+        optional: true
+
+  '@parcel/source-map@2.1.1':
+    resolution: {integrity: sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==}
+    engines: {node: ^12.18.3 || >=14}
+
+  '@parcel/transformer-babel@2.14.4':
+    resolution: {integrity: sha512-9yMnlFuKQYgXJY8OWpcR2vSigpMm5MCEJJl6r+g3KkXHFwK1Gket2sC4Wd5JbHv98SNzJ9rdD4Xrre/eXJu6pw==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-css@2.14.4':
+    resolution: {integrity: sha512-sf0NuzPH4kSpL4VgV94xY5kPxoAndoNouUFPaHmN3hW6QiTHShRubfDsginSOHl5QhghSfr4qtP7t7HxCSDq6A==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-html@2.14.4':
+    resolution: {integrity: sha512-h0iCfU2SN+gh5LTfZTRiXHavl3CdJ2i3F9jzVrRjdH8pfLqy5eOy1tQ8vyqMsshk+VdlZ1+vUiZ7uaKkkBq/fg==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-image@2.14.4':
+    resolution: {integrity: sha512-QVGAdQ16YxNo7PTzBazUabmrn4dss1EDeMrh0bFUeRTZdYaYu5z/+gnRc5R4oHcHK6oxnECi808TquMQcQxDEA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/transformer-js@2.14.4':
+    resolution: {integrity: sha512-fBC8NVM8xXxjGQY5r88Z46akSErFO5hRVA4kuRI0tkXorjov3Mu4hu6MLq974TEQluSvGXUYGT5Mq2iXZ75M7w==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@parcel/transformer-json@2.14.4':
+    resolution: {integrity: sha512-+28n3/qhc2q6Zoqhufk1YKU442a2JyyE0ILFsT17Of+lcNX+QtXYPOYcky7TNENnoUz9TpOAFev64P99UN7huA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-node@2.14.4':
+    resolution: {integrity: sha512-K5k/GkGN4SwGdil8g10AcPPJn+hV0vzcv4l2qYoCqaxxIPCrpjmMnoA8a3kRgxvD8s54KciFYYjmU5Cj5NjvbA==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-postcss@2.14.4':
+    resolution: {integrity: sha512-GxkXkcgG2XGt6ivoUF5yD1tmQPV+d71gUxyBGv1i1jg4x65R12Gc/npzWk9TCH2dShSdHOA90OJpNL4k0JlLtg==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-posthtml@2.14.4':
+    resolution: {integrity: sha512-V9dnsA5+t7uF/hWc9HwJcaKkmP8K2go6yAQOpxu+knyszfz3t2jw/k4L/VFjqCATf90agal/iRTPVkHvWDCzZw==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-raw@2.14.4':
+    resolution: {integrity: sha512-GCuUWKAb9YHB/krmzBeQbtHKKZopT3c3AzoPTq/4woV4Ti1zUZ83oFyTX1tBKQ+MMB1BW+HrPkFld0iY4gp/Ng==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-react-refresh-wrap@2.14.4':
+    resolution: {integrity: sha512-nb70CAvjDizAIQ1naZ39P/PxYWtPllWvvxrkpldNnk8AF74OcHodrsuHKwhyPZHMmnMdexFonsenf+VeN4l/aQ==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/transformer-svg@2.14.4':
+    resolution: {integrity: sha512-iqnyvgGmwu4wNh+khEBkMEu1hAGZWnc7/xQnhiuQBAcoy5qGNEjyVUv6PbMLWWAVK/0PjqV4FaB2deXBYKeW0A==}
+    engines: {node: '>= 16.0.0', parcel: ^2.14.4}
+
+  '@parcel/types-internal@2.14.4':
+    resolution: {integrity: sha512-Y2JnljFG7KcxLrCiYNCqBfjDo12alhRVpNugm0jwz1EQ3OQNO3HYiB0f3djq6pv2clZ5ndpgkNgYsn6L7KR9Nw==}
+
+  '@parcel/types@2.14.4':
+    resolution: {integrity: sha512-NL4N9M6IPwBquAo1DKOPqy66nwJLXMX3KPalzAA7ktt3HYr5YNG5h3GeVXPOLNIVVMrSIiodYGPEeEBYy6kyYA==}
+
+  '@parcel/utils@2.14.4':
+    resolution: {integrity: sha512-icK6QgKjis+UZLyaHJcsKXYOSKYeYr41m8ZB9j20/yEcvrMqj/LMVsNjLz3iWVhLwfgussG2ODxycCdu3M5cvQ==}
+    engines: {node: '>= 16.0.0'}
+
+  '@parcel/watcher-android-arm64@2.5.1':
+    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.1':
+    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.1':
+    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.5.1':
+    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.1':
+    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.1':
+    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.1':
+    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
+    engines: {node: '>= 10.0.0'}
+
+  '@parcel/workers@2.14.4':
+    resolution: {integrity: sha512-OAjW2dJOaRKy4UD5YwnUi7mY+gt/QbjagjrKh2fQDnrvuK8dpr5GrjEOLOe6QsxEE0vpe3jshhGMJTYqLni3kQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.14.4
+
+  '@swc/core-darwin-arm64@1.11.24':
+    resolution: {integrity: sha512-dhtVj0PC1APOF4fl5qT2neGjRLgHAAYfiVP8poJelhzhB/318bO+QCFWAiimcDoyMgpCXOhTp757gnoJJrheWA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.11.24':
+    resolution: {integrity: sha512-H/3cPs8uxcj2Fe3SoLlofN5JG6Ny5bl8DuZ6Yc2wr7gQFBmyBkbZEz+sPVgsID7IXuz7vTP95kMm1VL74SO5AQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.11.24':
+    resolution: {integrity: sha512-PHJgWEpCsLo/NGj+A2lXZ2mgGjsr96ULNW3+T3Bj2KTc8XtMUkE8tmY2Da20ItZOvPNC/69KroU7edyo1Flfbw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.11.24':
+    resolution: {integrity: sha512-C2FJb08+n5SD4CYWCTZx1uR88BN41ZieoHvI8A55hfVf2woT8+6ZiBzt74qW2g+ntZ535Jts5VwXAKdu41HpBg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.11.24':
+    resolution: {integrity: sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.11.24':
+    resolution: {integrity: sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.11.24':
+    resolution: {integrity: sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.11.24':
+    resolution: {integrity: sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.11.24':
+    resolution: {integrity: sha512-9pKLIisE/Hh2vJhGIPvSoTK4uBSPxNVyXHmOrtdDot4E1FUUI74Vi8tFdlwNbaj8/vusVnb8xPXsxF1uB0VgiQ==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.11.24':
+    resolution: {integrity: sha512-sybnXtOsdB+XvzVFlBVGgRHLqp3yRpHK7CrmpuDKszhj/QhmsaZzY/GHSeALlMtLup13M0gqbcQvsTNlAHTg3w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.11.24':
+    resolution: {integrity: sha512-MaQEIpfcEMzx3VWWopbofKJvaraqmL6HbLlw2bFZ7qYqYw3rkhM0cQVEgyzbHtTWwCwPMFZSC2DUbhlZgrMfLg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.17':
+    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
+  '@swc/types@0.1.21':
+    resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  browserslist@4.24.5:
+    resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001716:
+    resolution: {integrity: sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cosmiconfig@9.0.0:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  dom-serializer@1.4.1:
+    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@4.3.1:
+    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+    engines: {node: '>= 4'}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@2.8.0:
+    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv-expand@11.0.7:
+    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.5.0:
+    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+    engines: {node: '>=12'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  electron-to-chromium@1.5.149:
+    resolution: {integrity: sha512-UyiO82eb9dVOx8YO3ajDf9jz2kKyt98DEITRdeLPstOEuTlLzDA4Gyq5K9he71TQziU5jUVu2OAu5N48HmQiyQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
+  entities@3.0.1:
+    resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
+    engines: {node: '>=0.12'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-port@4.2.0:
+    resolution: {integrity: sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==}
+    engines: {node: '>=6'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@11.0.2:
+    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  htmlnano@2.1.2:
+    resolution: {integrity: sha512-8Fst+0bhAfU362S6oHVb4wtJj/UYEFr0qiCLAEi8zioqmp1JYBQx5crZAADlFVX0Ly/6s/IQz6G7PL9/hgoJaQ==}
+    peerDependencies:
+      cssnano: ^7.0.0
+      postcss: ^8.3.11
+      purgecss: ^7.0.2
+      relateurl: ^0.2.7
+      srcset: 5.0.1
+      svgo: ^3.0.2
+      terser: ^5.10.0
+      uncss: ^0.17.3
+    peerDependenciesMeta:
+      cssnano:
+        optional: true
+      postcss:
+        optional: true
+      purgecss:
+        optional: true
+      relateurl:
+        optional: true
+      srcset:
+        optional: true
+      svgo:
+        optional: true
+      terser:
+        optional: true
+      uncss:
+        optional: true
+
+  htmlparser2@7.2.0:
+    resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
+
+  htmlparser2@9.1.0:
+    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-json@2.0.1:
+    resolution: {integrity: sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@4.1.0:
+    resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
+    engines: {node: 20 || >=22}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-darwin-arm64@1.29.3:
+    resolution: {integrity: sha512-fb7raKO3pXtlNbQbiMeEu8RbBVHnpyqAoxTyTRMEWFQWmscGC2wZxoHzZ+YKAepUuKT9uIW5vL2QbFivTgprZg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.29.3:
+    resolution: {integrity: sha512-KF2XZ4ZdmDGGtEYmx5wpzn6u8vg7AdBHaEOvDKu8GOs7xDL/vcU2vMKtTeNe1d4dogkDdi3B9zC77jkatWBwEQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.29.3:
+    resolution: {integrity: sha512-VUWeVf+V1UM54jv9M4wen9vMlIAyT69Krl9XjI8SsRxz4tdNV/7QEPlW6JASev/pYdiynUCW0pwaFquDRYdxMw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.29.3:
+    resolution: {integrity: sha512-UhgZ/XVNfXQVEJrMIWeK1Laj8KbhjbIz7F4znUk7G4zeGw7TRoJxhb66uWrEsonn1+O45w//0i0Fu0wIovYdYg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.29.3:
+    resolution: {integrity: sha512-Pqau7jtgJNmQ/esugfmAT1aCFy/Gxc92FOxI+3n+LbMHBheBnk41xHDhc0HeYlx9G0xP5tK4t0Koy3QGGNqypw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.29.3:
+    resolution: {integrity: sha512-dxakOk66pf7KLS7VRYFO7B8WOJLecE5OPL2YOk52eriFd/yeyxt2Km5H0BjLfElokIaR+qWi33gB8MQLrdAY3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.29.3:
+    resolution: {integrity: sha512-ySZTNCpbfbK8rqpKJeJR2S0g/8UqqV3QnzcuWvpI60LWxnFN91nxpSSwCbzfOXkzKfar9j5eOuOplf+klKtINg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.29.3:
+    resolution: {integrity: sha512-3pVZhIzW09nzi10usAXfIGTTSTYQ141dk88vGFNCgawIzayiIzZQxEcxVtIkdvlEq2YuFsL9Wcj/h61JHHzuFQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.29.3:
+    resolution: {integrity: sha512-VRnkAvtIkeWuoBJeGOTrZxsNp4HogXtcaaLm8agmbYtLDOhQdpgxW6NjZZjDXbvGF+eOehGulXZ3C1TiwHY4QQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.29.3:
+    resolution: {integrity: sha512-IszwRPu2cPnDQsZpd7/EAr0x2W7jkaWqQ1SwCVIZ/tSbZVXPLt6k8s6FkcyBjViCzvB5CW0We0QbbP7zp2aBjQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.29.3:
+    resolution: {integrity: sha512-GlOJwTIP6TMIlrTFsxTerwC0W6OpQpCGuX1ECRLBUVRh6fpJH3xTqjCjRgQHTb4ZXexH9rtHou1Lf03GKzmhhQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lmdb@2.8.5:
+    resolution: {integrity: sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==}
+    hasBin: true
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mitata@1.0.34:
+    resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
+
+  mocha@10.8.2:
+    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
+    engines: {node: '>= 14.0.0'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.2:
+    resolution: {integrity: sha512-F9UngXRlPyWCDEASDpTf6c9uNhGPTqnTeLVt7bN+bU1eajoR/8V9ys2BRaV5C/e5ihE6sJ9uPIKaYt6bFuO32g==}
+
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nullthrows@1.1.1:
+    resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  ordered-binary@1.5.3:
+    resolution: {integrity: sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parcel@2.14.4:
+    resolution: {integrity: sha512-XmnIurC4CPdQm9OFJMbjgvto5Jz2szZ5/p6EY4pAljU/SLPhtBzJ3+J6OyljGFdbVxEXx4dp+7Cvf7eaDZsEEg==}
+    engines: {node: '>= 16.0.0'}
+    hasBin: true
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  posthtml-parser@0.11.0:
+    resolution: {integrity: sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==}
+    engines: {node: '>=12'}
+
+  posthtml-parser@0.12.1:
+    resolution: {integrity: sha512-rYFmsDLfYm+4Ts2Oh4DCDSZPtdC1BLnRXAobypVzX9alj28KGl65dIFtgDY9zB57D0TC4Qxqrawuq/2et1P0GA==}
+    engines: {node: '>=16'}
+
+  posthtml-render@3.0.0:
+    resolution: {integrity: sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==}
+    engines: {node: '>=12'}
+
+  posthtml@0.16.6:
+    resolution: {integrity: sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==}
+    engines: {node: '>=12.0.0'}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  react-refresh@0.16.0:
+    resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
+    engines: {node: '>=0.10.0'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  srcset@4.0.0:
+    resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
+    engines: {node: '>=12'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
+
+  weak-lru-cache@1.2.2:
+    resolution: {integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==}
+
+  web-tree-sitter@0.22.6:
+    resolution: {integrity: sha512-hS87TH71Zd6mGAmYCvlgxeGDjqd9GTeqXNqTT+u0Gs51uIozNIaaq/kUAbV/Zf56jb2ZOyG8BxZs2GG9wbLi6Q==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  xmldom@0.6.0:
+    resolution: {integrity: sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==}
+    engines: {node: '>=10.0.0'}
+
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.27.1': {}
+
+  '@babel/core@7.27.1':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/helper-compilation-targets': 7.27.1
+      '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
+      '@babel/helpers': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/template': 7.27.1
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
+      convert-source-map: 2.0.0
+      debug: 4.4.0(supports-color@8.1.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.27.1':
+    dependencies:
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.1':
+    dependencies:
+      '@babel/compat-data': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.24.5
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.27.1(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.27.1':
+    dependencies:
+      '@babel/template': 7.27.1
+      '@babel/types': 7.27.1
+
+  '@babel/parser@7.27.1':
+    dependencies:
+      '@babel/types': 7.27.1
+
+  '@babel/template@7.27.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
+
+  '@babel/traverse@7.27.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/template': 7.27.1
+      '@babel/types': 7.27.1
+      debug: 4.4.0(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/gen-mapping@0.3.8':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@lezer/common@1.2.3': {}
+
+  '@lezer/lr@1.4.2':
+    dependencies:
+      '@lezer/common': 1.2.3
+
+  '@lmdb/lmdb-darwin-arm64@2.8.5':
+    optional: true
+
+  '@lmdb/lmdb-darwin-x64@2.8.5':
+    optional: true
+
+  '@lmdb/lmdb-linux-arm64@2.8.5':
+    optional: true
+
+  '@lmdb/lmdb-linux-arm@2.8.5':
+    optional: true
+
+  '@lmdb/lmdb-linux-x64@2.8.5':
+    optional: true
+
+  '@lmdb/lmdb-win32-x64@2.8.5':
+    optional: true
+
+  '@mischnic/json-sourcemap@0.1.1':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/lr': 1.4.2
+      json5: 2.2.3
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
+  '@parcel/bundler-default@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/graph': 3.4.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/cache@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/fs': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/logger': 2.14.4
+      '@parcel/utils': 2.14.4
+      lmdb: 2.8.5
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@parcel/codeframe@2.14.4':
+    dependencies:
+      chalk: 4.1.2
+
+  '@parcel/compressor-raw@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/config-default@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@parcel/bundler-default': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/compressor-raw': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/namer-default': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/optimizer-css': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/optimizer-htmlnano': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/optimizer-image': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/optimizer-svgo': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/optimizer-swc': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
+      '@parcel/packager-css': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/packager-html': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/packager-js': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/packager-raw': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/packager-svg': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/packager-wasm': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/reporter-dev-server': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/resolver-default': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/runtime-browser-hmr': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/runtime-js': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/runtime-rsc': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/runtime-service-worker': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-babel': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-css': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-html': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-image': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-js': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-json': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-node': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-postcss': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-posthtml': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-raw': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-react-refresh-wrap': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/transformer-svg': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - cssnano
+      - napi-wasm
+      - postcss
+      - purgecss
+      - relateurl
+      - srcset
+      - svgo
+      - terser
+      - typescript
+      - uncss
+
+  '@parcel/core@2.14.4(@swc/helpers@0.5.17)':
+    dependencies:
+      '@mischnic/json-sourcemap': 0.1.1
+      '@parcel/cache': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/events': 2.14.4
+      '@parcel/feature-flags': 2.14.4
+      '@parcel/fs': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/graph': 3.4.4
+      '@parcel/logger': 2.14.4
+      '@parcel/package-manager': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/profiler': 2.14.4
+      '@parcel/rust': 2.14.4
+      '@parcel/source-map': 2.1.1
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      base-x: 3.0.11
+      browserslist: 4.24.5
+      clone: 2.1.2
+      dotenv: 16.5.0
+      dotenv-expand: 11.0.7
+      json5: 2.2.3
+      msgpackr: 1.11.2
+      nullthrows: 1.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - napi-wasm
+
+  '@parcel/diagnostic@2.14.4':
+    dependencies:
+      '@mischnic/json-sourcemap': 0.1.1
+      nullthrows: 1.1.1
+
+  '@parcel/error-overlay@2.14.4': {}
+
+  '@parcel/events@2.14.4': {}
+
+  '@parcel/feature-flags@2.14.4': {}
+
+  '@parcel/fs@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/feature-flags': 2.14.4
+      '@parcel/rust': 2.14.4
+      '@parcel/types-internal': 2.14.4
+      '@parcel/utils': 2.14.4
+      '@parcel/watcher': 2.5.1
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@parcel/graph@3.4.4':
+    dependencies:
+      '@parcel/feature-flags': 2.14.4
+      nullthrows: 1.1.1
+
+  '@parcel/logger@2.14.4':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/events': 2.14.4
+
+  '@parcel/markdown-ansi@2.14.4':
+    dependencies:
+      chalk: 4.1.2
+
+  '@parcel/namer-default@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/node-resolver-core@3.5.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@mischnic/json-sourcemap': 0.1.1
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/fs': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/optimizer-css@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+      browserslist: 4.24.5
+      lightningcss: 1.29.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/optimizer-htmlnano@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      htmlnano: 2.1.2
+      nullthrows: 1.1.1
+      posthtml: 0.16.6
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - cssnano
+      - napi-wasm
+      - postcss
+      - purgecss
+      - relateurl
+      - srcset
+      - svgo
+      - terser
+      - typescript
+      - uncss
+
+  '@parcel/optimizer-image@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/utils': 2.14.4
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@parcel/optimizer-svgo@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/optimizer-swc@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+      '@swc/core': 1.11.24(@swc/helpers@0.5.17)
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - '@swc/helpers'
+      - napi-wasm
+
+  '@parcel/package-manager@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/fs': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/logger': 2.14.4
+      '@parcel/node-resolver-core': 3.5.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@swc/core': 1.11.24(@swc/helpers@0.5.17)
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - napi-wasm
+
+  '@parcel/packager-css@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+      lightningcss: 1.29.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/packager-html@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+      posthtml: 0.16.6
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/packager-js@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/source-map': 2.1.1
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      globals: 13.24.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/packager-raw@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/packager-svg@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      posthtml: 0.16.6
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/packager-wasm@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/plugin@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/profiler@2.14.4':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/events': 2.14.4
+      '@parcel/types-internal': 2.14.4
+      chrome-trace-event: 1.0.4
+
+  '@parcel/reporter-cli@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/types': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      chalk: 4.1.2
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/reporter-dev-server@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/codeframe': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/reporter-tracer@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      chrome-trace-event: 1.0.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/resolver-default@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/node-resolver-core': 3.5.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/runtime-browser-hmr@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/runtime-js@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/runtime-rsc@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/runtime-service-worker@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/rust@2.14.4': {}
+
+  '@parcel/source-map@2.1.1':
+    dependencies:
+      detect-libc: 1.0.3
+
+  '@parcel/transformer-babel@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+      browserslist: 4.24.5
+      json5: 2.2.3
+      nullthrows: 1.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-css@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+      browserslist: 4.24.5
+      lightningcss: 1.29.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-html@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      nullthrows: 1.1.1
+      posthtml: 0.16.6
+      posthtml-parser: 0.12.1
+      posthtml-render: 3.0.0
+      semver: 7.7.1
+      srcset: 4.0.0
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-image@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@parcel/transformer-js@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/source-map': 2.1.1
+      '@parcel/utils': 2.14.4
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@swc/helpers': 0.5.17
+      browserslist: 4.24.5
+      nullthrows: 1.1.1
+      regenerator-runtime: 0.14.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@parcel/transformer-json@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      json5: 2.2.3
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-node@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-postcss@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      '@parcel/utils': 2.14.4
+      clone: 2.1.2
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-posthtml@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+      posthtml: 0.16.6
+      posthtml-parser: 0.12.1
+      posthtml-render: 3.0.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-raw@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-react-refresh-wrap@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/error-overlay': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      react-refresh: 0.16.0
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/transformer-svg@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/plugin': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/rust': 2.14.4
+      nullthrows: 1.1.1
+      posthtml: 0.16.6
+      posthtml-parser: 0.12.1
+      posthtml-render: 3.0.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/types-internal@2.14.4':
+    dependencies:
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/feature-flags': 2.14.4
+      '@parcel/source-map': 2.1.1
+      utility-types: 3.11.0
+
+  '@parcel/types@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/types-internal': 2.14.4
+      '@parcel/workers': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - '@parcel/core'
+      - napi-wasm
+
+  '@parcel/utils@2.14.4':
+    dependencies:
+      '@parcel/codeframe': 2.14.4
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/logger': 2.14.4
+      '@parcel/markdown-ansi': 2.14.4
+      '@parcel/rust': 2.14.4
+      '@parcel/source-map': 2.1.1
+      chalk: 4.1.2
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@parcel/watcher-android-arm64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.1':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.1':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.1':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.1':
+    optional: true
+
+  '@parcel/watcher@2.5.1':
+    dependencies:
+      detect-libc: 1.0.3
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      node-addon-api: 7.1.1
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.1
+      '@parcel/watcher-darwin-arm64': 2.5.1
+      '@parcel/watcher-darwin-x64': 2.5.1
+      '@parcel/watcher-freebsd-x64': 2.5.1
+      '@parcel/watcher-linux-arm-glibc': 2.5.1
+      '@parcel/watcher-linux-arm-musl': 2.5.1
+      '@parcel/watcher-linux-arm64-glibc': 2.5.1
+      '@parcel/watcher-linux-arm64-musl': 2.5.1
+      '@parcel/watcher-linux-x64-glibc': 2.5.1
+      '@parcel/watcher-linux-x64-musl': 2.5.1
+      '@parcel/watcher-win32-arm64': 2.5.1
+      '@parcel/watcher-win32-ia32': 2.5.1
+      '@parcel/watcher-win32-x64': 2.5.1
+
+  '@parcel/workers@2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))':
+    dependencies:
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/logger': 2.14.4
+      '@parcel/profiler': 2.14.4
+      '@parcel/types-internal': 2.14.4
+      '@parcel/utils': 2.14.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - napi-wasm
+
+  '@swc/core-darwin-arm64@1.11.24':
+    optional: true
+
+  '@swc/core-darwin-x64@1.11.24':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.11.24':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.11.24':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.11.24':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.11.24':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.11.24':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.11.24':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.11.24':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.11.24':
+    optional: true
+
+  '@swc/core@1.11.24(@swc/helpers@0.5.17)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.21
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.11.24
+      '@swc/core-darwin-x64': 1.11.24
+      '@swc/core-linux-arm-gnueabihf': 1.11.24
+      '@swc/core-linux-arm64-gnu': 1.11.24
+      '@swc/core-linux-arm64-musl': 1.11.24
+      '@swc/core-linux-x64-gnu': 1.11.24
+      '@swc/core-linux-x64-musl': 1.11.24
+      '@swc/core-win32-arm64-msvc': 1.11.24
+      '@swc/core-win32-ia32-msvc': 1.11.24
+      '@swc/core-win32-x64-msvc': 1.11.24
+      '@swc/helpers': 0.5.17
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.17':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/types@0.1.21':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-colors@4.1.3: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@2.0.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browser-stdout@1.3.1: {}
+
+  browserslist@4.24.5:
+    dependencies:
+      caniuse-lite: 1.0.30001716
+      electron-to-chromium: 1.5.149
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.24.5)
+
+  callsites@3.1.0: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001716: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chrome-trace-event@1.0.4: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clone@2.1.2: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@12.1.0: {}
+
+  convert-source-map@2.0.0: {}
+
+  cosmiconfig@9.0.0:
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.0(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
+
+  detect-libc@1.0.3: {}
+
+  detect-libc@2.0.4: {}
+
+  diff@5.2.0: {}
+
+  dom-serializer@1.4.1:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      entities: 2.2.0
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@4.3.1:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@2.8.0:
+    dependencies:
+      dom-serializer: 1.4.1
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.5.0
+
+  dotenv@16.5.0: {}
+
+  eastasianwidth@0.2.0: {}
+
+  electron-to-chromium@1.5.149: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  entities@2.2.0: {}
+
+  entities@3.0.1: {}
+
+  entities@4.5.0: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.0.6: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat@5.0.2: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-port@4.2.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@11.0.2:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.0
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+
+  globals@11.12.0: {}
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  has-flag@4.0.0: {}
+
+  he@1.2.0: {}
+
+  htmlnano@2.1.2:
+    dependencies:
+      cosmiconfig: 9.0.0
+      posthtml: 0.16.6
+    transitivePeerDependencies:
+      - typescript
+
+  htmlparser2@7.2.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+      entities: 3.0.1
+
+  htmlparser2@9.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-json@2.0.1: {}
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@2.1.0: {}
+
+  is-unicode-supported@0.1.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@4.1.0:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-darwin-arm64@1.29.3:
+    optional: true
+
+  lightningcss-darwin-x64@1.29.3:
+    optional: true
+
+  lightningcss-freebsd-x64@1.29.3:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.29.3:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.29.3:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.29.3:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.29.3:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.29.3:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.29.3:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.29.3:
+    optional: true
+
+  lightningcss@1.29.3:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.3
+      lightningcss-darwin-x64: 1.29.3
+      lightningcss-freebsd-x64: 1.29.3
+      lightningcss-linux-arm-gnueabihf: 1.29.3
+      lightningcss-linux-arm64-gnu: 1.29.3
+      lightningcss-linux-arm64-musl: 1.29.3
+      lightningcss-linux-x64-gnu: 1.29.3
+      lightningcss-linux-x64-musl: 1.29.3
+      lightningcss-win32-arm64-msvc: 1.29.3
+      lightningcss-win32-x64-msvc: 1.29.3
+
+  lines-and-columns@1.2.4: {}
+
+  lmdb@2.8.5:
+    dependencies:
+      msgpackr: 1.11.2
+      node-addon-api: 6.1.0
+      node-gyp-build-optional-packages: 5.1.1
+      ordered-binary: 1.5.3
+      weak-lru-cache: 1.2.2
+    optionalDependencies:
+      '@lmdb/lmdb-darwin-arm64': 2.8.5
+      '@lmdb/lmdb-darwin-x64': 2.8.5
+      '@lmdb/lmdb-linux-arm': 2.8.5
+      '@lmdb/lmdb-linux-arm64': 2.8.5
+      '@lmdb/lmdb-linux-x64': 2.8.5
+      '@lmdb/lmdb-win32-x64': 2.8.5
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  lru-cache@11.1.0: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minipass@7.1.2: {}
+
+  mitata@1.0.34: {}
+
+  mocha@10.8.2:
+    dependencies:
+      ansi-colors: 4.1.3
+      browser-stdout: 1.3.1
+      chokidar: 3.6.0
+      debug: 4.4.0(supports-color@8.1.1)
+      diff: 5.2.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 8.1.0
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 5.1.6
+      ms: 2.1.3
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 6.5.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
+
+  ms@2.1.3: {}
+
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.2:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
+  node-addon-api@6.1.0: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.0.4
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.0.4
+    optional: true
+
+  node-releases@2.0.19: {}
+
+  normalize-path@3.0.0: {}
+
+  nullthrows@1.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  ordered-binary@1.5.3: {}
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  parcel@2.14.4(@swc/helpers@0.5.17):
+    dependencies:
+      '@parcel/config-default': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
+      '@parcel/core': 2.14.4(@swc/helpers@0.5.17)
+      '@parcel/diagnostic': 2.14.4
+      '@parcel/events': 2.14.4
+      '@parcel/feature-flags': 2.14.4
+      '@parcel/fs': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/logger': 2.14.4
+      '@parcel/package-manager': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
+      '@parcel/reporter-cli': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/reporter-dev-server': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/reporter-tracer': 2.14.4(@parcel/core@2.14.4(@swc/helpers@0.5.17))
+      '@parcel/utils': 2.14.4
+      chalk: 4.1.2
+      commander: 12.1.0
+      get-port: 4.2.0
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - cssnano
+      - napi-wasm
+      - postcss
+      - purgecss
+      - relateurl
+      - srcset
+      - svgo
+      - terser
+      - typescript
+      - uncss
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-browserify@1.0.1: {}
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  postcss-value-parser@4.2.0: {}
+
+  posthtml-parser@0.11.0:
+    dependencies:
+      htmlparser2: 7.2.0
+
+  posthtml-parser@0.12.1:
+    dependencies:
+      htmlparser2: 9.1.0
+
+  posthtml-render@3.0.0:
+    dependencies:
+      is-json: 2.0.1
+
+  posthtml@0.16.6:
+    dependencies:
+      posthtml-parser: 0.11.0
+      posthtml-render: 3.0.0
+
+  process@0.11.10: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  react-refresh@0.16.0: {}
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
+
+  regenerator-runtime@0.14.1: {}
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
+
+  safe-buffer@5.2.1: {}
+
+  sax@1.4.1: {}
+
+  semver@6.3.1: {}
+
+  semver@7.7.1: {}
+
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  srcset@4.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  term-size@2.2.1: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tslib@2.8.1: {}
+
+  type-fest@0.20.2: {}
+
+  update-browserslist-db@1.1.3(browserslist@4.24.5):
+    dependencies:
+      browserslist: 4.24.5
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  utility-types@3.11.0: {}
+
+  weak-lru-cache@1.2.2: {}
+
+  web-tree-sitter@0.22.6: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  workerpool@6.5.1: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
+  wrappy@1.0.2: {}
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  xmldom@0.6.0: {}
+
+  xpath@0.0.34: {}
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yocto-queue@0.1.0: {}

--- a/web-usfm-parser/src/testingTreeWalker.js
+++ b/web-usfm-parser/src/testingTreeWalker.js
@@ -1,0 +1,7 @@
+// This fill will be deleted. This function merely exists during PR to show on benchmakrs how much overhead there is to walking the three via children only.
+export function walkTheTree(node) {
+  let type = node.type;
+  node.children.forEach((child) => {
+    walkTheTree(child);
+  });
+}

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -8,6 +8,7 @@ import ListGenerator from "./listGenerator.js";
 import USXGenerator from "./usxGenerator.js";
 import {ORIGINAL_VREF} from "./utils/vrefs.js";
 import {Filter} from "./filters.js";
+import {walkTheTree} from "./testingTreeWalker.js";
 
 class USFMParser {
   static language = null;
@@ -129,6 +130,9 @@ Only one of USFM, USJ, USX or BibleNLP is supported in one object.`);
       (combineTexts = combineTexts)
     );
     return this.usj;
+  }
+  walkTheTree() {
+    return walkTheTree(this.syntaxTree);
   }
 
   usjToUsfm(usjObject) {

--- a/web-usfm-parser/src/usfmParser.js
+++ b/web-usfm-parser/src/usfmParser.js
@@ -1,385 +1,507 @@
-
-import assert from 'assert';
-import Parser from './web-tree-sitter/tree-sitter.js';
+import assert from "assert";
+import Parser from "./web-tree-sitter/tree-sitter.js";
 
 import USFMGenerator from "./usfmGenerator.js";
 import USJGenerator from "./usjGenerator.js";
-import ListGenerator from "./listGenerator.js"
+import USJGenerator2 from "./usjGenerator2.js";
+import ListGenerator from "./listGenerator.js";
 import USXGenerator from "./usxGenerator.js";
 import {ORIGINAL_VREF} from "./utils/vrefs.js";
-import { Filter } from "./filters.js";
-
+import {Filter} from "./filters.js";
 
 class USFMParser {
-	static language = null;
-	static async init(grammarPath="node_modules/usfm-grammar/tree-sitter-usfm.wasm",
+  static language = null;
+  static async init(
+    grammarPath = "node_modules/usfm-grammar/tree-sitter-usfm.wasm",
 
-					parserPath="node_modules/usfm-grammar/tree-sitter.wasm") {
-		await Parser.init( {
-				  locateFile() {
-				    return parserPath;
-				  },
-				} );
-		USFMParser.language = await Parser.Language.load(grammarPath);
-	}
+    parserPath = "node_modules/usfm-grammar/tree-sitter.wasm"
+  ) {
+    await Parser.init({
+      locateFile() {
+        return parserPath;
+      },
+    });
+    USFMParser.language = await Parser.Language.load(grammarPath);
+  }
 
-	constructor(usfmString=null, fromUsj=null, fromUsx=null, fromBibleNlp=null, bookCode=null) {
-		this.syntaxTree = null;
-		this.errors = [];
-        this.warnings = [];
-        
-		let inputsGiven = 0
-        if (usfmString !== null) {
-            inputsGiven += 1
+  constructor(
+    usfmString = null,
+    fromUsj = null,
+    fromUsx = null,
+    fromBibleNlp = null,
+    bookCode = null
+  ) {
+    this.syntaxTree = null;
+    this.errors = [];
+    this.warnings = [];
+
+    let inputsGiven = 0;
+    if (usfmString !== null) {
+      inputsGiven += 1;
+    }
+    if (fromUsj !== null) {
+      inputsGiven += 1;
+    }
+    if (fromUsx !== null) {
+      inputsGiven += 1;
+    }
+    if (fromBibleNlp !== null) {
+      inputsGiven += 1;
+    }
+
+    if (inputsGiven > 1) {
+      throw new Error(`Found more than one input!
+Only one of USFM, USJ, USX or BibleNLP is supported in one object.`);
+    }
+    if (inputsGiven === 0) {
+      throw Error(
+        "Missing input! Either USFM, USJ, USX or BibleNLP is to be provided."
+      );
+    }
+
+    if (usfmString !== null) {
+      if (
+        typeof usfmString !== "string" ||
+        !usfmString.trim().startsWith("\\")
+      ) {
+        throw new Error(
+          "Invalid input for USFM. Expected a string with \\ markups."
+        );
+      }
+      this.usfm = usfmString;
+    } else if (fromUsj !== null) {
+      this.usj = fromUsj;
+      this.usfm = this.convertUSJToUSFM();
+    } else if (fromUsx !== null) {
+      this.usx = fromUsx;
+      this.usfm = this.convertUSXToUSFM();
+    } else if (fromBibleNlp !== null) {
+      this.bibleNlp = fromBibleNlp;
+      this.usfm = this.convertBibleNLPtoUSFM(bookCode);
+    }
+    this.parser = null;
+    this.initializeParser();
+
+    this.parseUSFM();
+  }
+
+  initializeParser() {
+    if (!USFMParser.language) {
+      throw new Error(
+        "USFMParser not initialized. Call USFMParser.init() before creating instances."
+      );
+    }
+    this.parser = new Parser();
+    this.parser.setLanguage(USFMParser.language);
+    this.parserOptions = Parser.Options = {
+      bufferSize: 1024 * 1024,
+    };
+  }
+
+  toSyntaxTree() {
+    return this.syntaxTree.toString();
+  }
+
+  toUSJ(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    this.usj = this.convertUSFMToUSJ(
+      (excludeMarkers = excludeMarkers),
+      (includeMarkers = includeMarkers),
+      (ignoreErrors = ignoreErrors),
+      (combineTexts = combineTexts)
+    );
+    return this.usj;
+  }
+  toUSJ2(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    this.usj = this.convertUSFMToUSJ2(
+      (excludeMarkers = excludeMarkers),
+      (includeMarkers = includeMarkers),
+      (ignoreErrors = ignoreErrors),
+      (combineTexts = combineTexts)
+    );
+    return this.usj;
+  }
+
+  usjToUsfm(usjObject) {
+    if (
+      typeof usjObject !== "object" ||
+      usjObject === null ||
+      !usjObject.hasOwnProperty("type")
+    ) {
+      throw new Error("Invalid input for USJ. Expected an object.");
+    }
+    if (!this.parser) {
+      this.initializeParser();
+    }
+    this.usj = usjObject;
+    this.usfm = this.convertUSJToUSFM();
+    return this.usfm;
+  }
+
+  convertUSXToUSFM() {
+    try {
+      if (!(1 <= this.usx.nodeType && this.usx.nodeType <= 12)) {
+        throw new Error(
+          "Input must be an instance of xmldom Document or Element"
+        );
+      }
+      if (this.usx.tagName !== "usx") {
+        if (!(this.usx.getElementsByTagName("usx").length === 1)) {
+          throw new Error(
+            "Expects a <usx> node. Refer docs: https://docs.usfm.bible/usfm/3.1/syntax.html#_usx_usfm_xml"
+          );
         }
-        if (fromUsj !== null) {
-            inputsGiven += 1
+
+        this.usx = this.usx.getElementsByTagName("usx")[0];
+      }
+      // assert(this.usx.childNodes[0].tagName === 'book', "<book> expected as first element in <usx>")
+    } catch (err) {
+      throw new Error("USX not in expected format. " + err.message);
+    }
+    try {
+      const usfmGen = new USFMGenerator();
+      usfmGen.usxToUsfm(this.usx);
+      // console.log(usfmGen.usfmString)
+      return usfmGen.usfmString;
+    } catch (err) {
+      let message = "Unable to do the conversion from USX to USFM. ";
+      throw new Error(message, {cause: err});
+    }
+  }
+
+  parseUSFM() {
+    let tree = null;
+    try {
+      if (this.usfm.length > 25000) {
+        tree = this.parser.parse(this.usfm, null, this.parserOptions);
+      } else {
+        tree = this.parser.parse(this.usfm);
+      }
+    } catch (err) {
+      throw err;
+      // console.log("Error in parser.parse()");
+      // console.log(err.toString());
+      // console.log(this.usfm);
+    }
+    this.checkForErrors(tree);
+    this.checkforMissing(tree.rootNode);
+    // if (error) throw error;
+    this.syntaxTree = tree.rootNode;
+  }
+
+  checkForErrors(tree) {
+    const errorQuery = this.parser.getLanguage().query("(ERROR) @errors");
+    const errors = errorQuery.captures(tree.rootNode);
+    if (errors.length > 0) {
+      this.errors = errors.map(
+        (err) =>
+          `At ${err.node.startPosition.row}:${
+            err.node.startPosition.column
+          }, Error: ${this.usfm.substring(
+            err.node.startIndex,
+            err.node.endIndex
+          )}`
+      );
+      return new Error(`Errors found in USFM: ${this.errors.join(", ")}`);
+    }
+    return null;
+  }
+
+  checkforMissing(node) {
+    for (let n of node.children) {
+      if (n.isMissing) {
+        this.errors.push(
+          `At ${n.startPosition.row + 1}:${
+            n.startPosition.column
+          }, Error: Missing ${n.type}`
+        );
+      }
+      this.checkforMissing(n);
+    }
+  }
+
+  convertUSJToUSFM() {
+    const outputUSFM = new USFMGenerator().usjToUsfm(this.usj); // Simulated conversion
+    return outputUSFM;
+  }
+
+  convertBibleNLPtoUSFM(bookCode) {
+    try {
+      assert(this.bibleNlp["vref"], "Should have 'vref' key");
+      assert(this.bibleNlp["text"], "Should have 'text' key");
+      assert(
+        Array.isArray(this.bibleNlp["vref"]),
+        "'vref' should contain an array of references."
+      );
+      assert(
+        Array.isArray(this.bibleNlp["text"]),
+        "'text' should contain an array of strings."
+      );
+      let vrefs = this.bibleNlp.vref;
+      if (
+        [31170, 23213].includes(this.bibleNlp.text.length) &&
+        vrefs.length === 41899
+      ) {
+        vrefs = vrefs.slice(0, this.bibleNlp.text.length);
+        this.bibleNlp.vref = vrefs;
+      }
+
+      if (bookCode !== null) {
+        bookCode = bookCode.trim().toUpperCase();
+        vrefs = this.bibleNlp.vref.filter((ref) =>
+          ref.trim().toUpperCase().startsWith(bookCode)
+        );
+      }
+
+      if (vrefs.length !== this.bibleNlp.text.length) {
+        if (
+          this.bibleNlp.vref.length === this.bibleNlp.text.length &&
+          bookCode !== null
+        ) {
+          let texts = this.bibleNlp.text.filter((txt, index) =>
+            this.bibleNlp.vref[index].trim().toUpperCase().startsWith(bookCode)
+          );
+          this.bibleNlp.text = texts;
         }
-        if (fromUsx !== null) {
-            inputsGiven += 1
+        if (vrefs.length !== this.bibleNlp.text.length) {
+          throw new Error(
+            `Mismatch in lengths of vref and text lists. ` +
+              `Specify a bookCode or check for versification differences. ` +
+              `${vrefs.length} != ${this.bibleNlp.text.length}`
+          );
         }
-        if (fromBibleNlp !== null) {
-            inputsGiven += 1;
-        }
+      }
+      this.bibleNlp.vref = vrefs;
+    } catch (err) {
+      throw new Error("BibleNLP object not in expected format. " + err.message);
+    }
+    try {
+      const usfmGen = new USFMGenerator();
+      usfmGen.bibleNlptoUsfm(this.bibleNlp);
+      this.warnings = usfmGen.warnings;
+      return usfmGen.usfmString;
+    } catch (err) {
+      let message = "Unable to do the conversion from BibleNLP to USFM. ";
+      throw new Error(message, {cause: err});
+    }
+  }
 
-        if (inputsGiven > 1) {
-            throw new  Error(`Found more than one input!
-Only one of USFM, USJ, USX or BibleNLP is supported in one object.`)
-        }
-        if (inputsGiven === 0) {
-            throw Error("Missing input! Either USFM, USJ, USX or BibleNLP is to be provided.")
-        }
+  convertUSFMToUSJ(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors = true, as third parameter of toUSJ(), to generate output despite errors.`
+      );
+    }
 
-        if (usfmString !== null) {
-        	if (typeof usfmString !== "string" || !usfmString.trim().startsWith("\\")) {
-				throw new Error("Invalid input for USFM. Expected a string with \\ markups.");
-			}
-            this.usfm = usfmString;
-        } else if(fromUsj !== null) {
-        	this.usj = fromUsj;
-        	this.usfm = this.convertUSJToUSFM()
-        } else if (fromUsx !== null) {
-        	this.usx = fromUsx;
-        	this.usfm = this.convertUSXToUSFM()
-        } else if (fromBibleNlp !== null) {
-        	this.bibleNlp = fromBibleNlp;
-        	this.usfm = this.convertBibleNLPtoUSFM(bookCode)
-        }
-		this.parser = null;
-		this.initializeParser();
+    let outputUSJ;
+    try {
+      let usjGenerator = new USJGenerator(
+        USFMParser.language,
+        this.usfm,
+        null,
+        this.syntaxTree
+      );
+      usjGenerator.nodeToUSJ(this.syntaxTree, usjGenerator.jsonRootObj);
+      outputUSJ = usjGenerator.jsonRootObj;
+    } catch (e) {
+      console.log(e);
+      // let message = "Unable to do the conversion. ";
+      // if (this.errors) {
+      //   let errorString = this.errors.join("\n\t");
+      //   message += `Could be due to an error in the USFM\n\t${errorString}`;
+      // } else {
+      //   message = err.message;
+      // }
+      // return {error: message};
+    }
 
-        this.parseUSFM();
-	}
+    if (includeMarkers) {
+      outputUSJ = Filter.keepOnly(
+        outputUSJ,
+        [...includeMarkers, "USJ"],
+        combineTexts
+      );
+    }
+    if (excludeMarkers) {
+      outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
+    }
 
-	initializeParser() {
-		if (!USFMParser.language) {
-			throw new Error(
-				"USFMParser not initialized. Call USFMParser.init() before creating instances.",
-			);
-		}
-		this.parser = new Parser();
-		this.parser.setLanguage(USFMParser.language);
-		this.parserOptions = Parser.Options = {
-						      bufferSize: 1024 * 1024,
-						    };
-	}
+    return outputUSJ;
+  }
+  convertUSFMToUSJ2(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors = true, as third parameter of toUSJ(), to generate output despite errors.`
+      );
+    }
 
-	toSyntaxTree() {
-		return this.syntaxTree.toString();
-	}
+    let outputUSJ;
+    try {
+      let usjGenerator = new USJGenerator2(
+        USFMParser.language,
+        this.usfm,
+        null,
+        this.syntaxTree
+      );
+      usjGenerator.getUsj(this.syntaxTree, usjGenerator.jsonRootObj);
+      outputUSJ = usjGenerator.jsonRootObj;
+    } catch (e) {
+      console.log(e);
+      // let message = "Unable to do the conversion. ";
+      // if (this.errors) {
+      //   let errorString = this.errors.join("\n\t");
+      //   message += `Could be due to an error in the USFM\n\t${errorString}`;
+      // } else {
+      //   message = err.message;
+      // }
+      // return {error: message};
+    }
 
-	toUSJ(excludeMarkers = null,
-		includeMarkers = null,
-		ignoreErrors = false,
-		combineTexts = true,) {
-		this.usj = this.convertUSFMToUSJ(excludeMarkers = excludeMarkers,
-								includeMarkers = includeMarkers,
-								ignoreErrors = ignoreErrors,
-								combineTexts = combineTexts,);
-		return this.usj;
-	}
+    if (includeMarkers) {
+      outputUSJ = Filter.keepOnly(
+        outputUSJ,
+        [...includeMarkers, "USJ"],
+        combineTexts
+      );
+    }
+    if (excludeMarkers) {
+      outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
+    }
 
-	usjToUsfm(usjObject) {
-		if (typeof usjObject !== "object" || usjObject === null || (!usjObject.hasOwnProperty('type'))) {
-			throw new Error("Invalid input for USJ. Expected an object.");
-		}
-		if (!this.parser) {
-			this.initializeParser();
-		}
-		this.usj = usjObject;
-		this.usfm = this.convertUSJToUSFM();
-		return this.usfm;
-	}
+    return outputUSJ;
+  }
 
-	convertUSXToUSFM() {
-		try {
-			if(!(1 <= this.usx.nodeType && this.usx.nodeType <= 12)) {
-				throw new Error('Input must be an instance of xmldom Document or Element');
-			} 
-			if (this.usx.tagName !== "usx") {
-				if(!(this.usx.getElementsByTagName('usx').length === 1)) {
-					throw new Error('Expects a <usx> node. Refer docs: https://docs.usfm.bible/usfm/3.1/syntax.html#_usx_usfm_xml');
-				}
-
-				this.usx = this.usx.getElementsByTagName('usx')[0]
-			}
-			// assert(this.usx.childNodes[0].tagName === 'book', "<book> expected as first element in <usx>")
-
-		} catch(err) {
-			throw new Error("USX not in expected format. "+err.message)
-		}
-		try {
-			const usfmGen = new USFMGenerator()
-			usfmGen.usxToUsfm(this.usx);
-			// console.log(usfmGen.usfmString)
-			return usfmGen.usfmString;
-		} catch(err) {
-	        let message = "Unable to do the conversion from USX to USFM. ";
-	        throw new Error(message, { cause: err });
-		}
-	}
-
-
-	parseUSFM() {
-		let tree = null;
-		try {
-			if (this.usfm.length > 25000) {
-				tree = this.parser.parse(this.usfm, null, this.parserOptions);
-			}
-			else {
-				tree = this.parser.parse(this.usfm);
-			}
-		} catch (err) {
-			throw err;
-			// console.log("Error in parser.parse()");
-			// console.log(err.toString());
-			// console.log(this.usfm);
-		}
-		this.checkForErrors(tree);
-		this.checkforMissing(tree.rootNode);
-		// if (error) throw error;
-		this.syntaxTree = tree.rootNode;
-	}
-
-
-	checkForErrors(tree) {
-		const errorQuery = this.parser.getLanguage().query("(ERROR) @errors");
-		const errors = errorQuery.captures(tree.rootNode);
-		if (errors.length > 0) {
-			this.errors = errors.map(
-				(err) =>
-					`At ${err.node.startPosition.row}:${err.node.startPosition.column}, Error: ${this.usfm.substring(err.node.startIndex, err.node.endIndex)}`,
-			);
-			return new Error(`Errors found in USFM: ${this.errors.join(", ")}`);
-		}
-		return null;
-	}
-
-	checkforMissing(node) {
-	   for (let n of node.children) {
-	        if (n.isMissing){
-	        		this.errors.push(
-						`At ${n.startPosition.row+1}:${n.startPosition.column}, Error: Missing ${n.type}`) 
-	        } 
-	        this.checkforMissing(n);
-	    }
-	}
-
-	convertUSJToUSFM() {
-		const outputUSFM = new USFMGenerator().usjToUsfm(this.usj); // Simulated conversion
-		return outputUSFM;
-	}
-
-	convertBibleNLPtoUSFM(bookCode) {
-		try {
-			assert(this.bibleNlp['vref'],
-				"Should have 'vref' key");
-			assert(this.bibleNlp['text'],
-				"Should have 'text' key");
-			assert(Array.isArray(this.bibleNlp['vref']),
-				"'vref' should contain an array of references.");
-			assert(Array.isArray(this.bibleNlp['text']),
-				"'text' should contain an array of strings.")
-			let vrefs = this.bibleNlp.vref;
-			if ([31170, 23213].includes(this.bibleNlp.text.length) && vrefs.length === 41899) {
-			    vrefs = vrefs.slice(0, this.bibleNlp.text.length);
-			    this.bibleNlp.vref =vrefs;			}
-
-			if (bookCode !== null) {
-				bookCode = bookCode.trim().toUpperCase();
-			    vrefs = this.bibleNlp.vref.filter(ref => ref.trim().toUpperCase().startsWith(bookCode));
-			}
-
-			if (vrefs.length !== this.bibleNlp.text.length) {
-			    if (this.bibleNlp.vref.length === this.bibleNlp.text.length && bookCode !== null) {
-			        let texts = this.bibleNlp.text.filter((txt, index) => 
-			            this.bibleNlp.vref[index].trim().toUpperCase().startsWith(bookCode)
-			        );
-			        this.bibleNlp.text = texts;
-			    }
-			    if (vrefs.length !== this.bibleNlp.text.length) {
-			        throw new Error(`Mismatch in lengths of vref and text lists. ` +
-			                        `Specify a bookCode or check for versification differences. ` +
-			                        `${vrefs.length} != ${this.bibleNlp.text.length}`);
-			    }
-			}
-			this.bibleNlp.vref = vrefs;
-		} catch(err) {
-			throw new Error("BibleNLP object not in expected format. "+err.message)
-		}
-		try {
-			const usfmGen = new USFMGenerator();
-			usfmGen.bibleNlptoUsfm(this.bibleNlp);
-			this.warnings = usfmGen.warnings;
-			return usfmGen.usfmString;
-		} catch(err) {
-			let message = "Unable to do the conversion from BibleNLP to USFM. ";
-			throw new Error(message, {cause: err});
-		}
-	}
-
-	convertUSFMToUSJ(
-		excludeMarkers = null,
-		includeMarkers = null,
-		ignoreErrors = false,
-		combineTexts = true,
-		) {
-		if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-			throw new Error(
-				`Errors present:\n\t${errorString}\nUse ignoreErrors = true, as third parameter of toUSJ(), to generate output despite errors.`,
-			);
-		}
-
-		let outputUSJ;
-		try {
-			let usjGenerator = new USJGenerator(
-				USFMParser.language,
-				this.usfm
-			);
-			usjGenerator.nodeToUSJ(this.syntaxTree, usjGenerator.jsonRootObj);
-			outputUSJ = usjGenerator.jsonRootObj;
-		} catch (err) {
-			let message = "Unable to do the conversion. ";
-			if (this.errors) {
-				let errorString = this.errors.join("\n\t");
-				message += `Could be due to an error in the USFM\n\t${errorString}`;
-			}
-			else {
-				message = err.message;
-			}
-			return {error: message};
-		}
-
-		if (includeMarkers) {
-			outputUSJ = Filter.keepOnly(outputUSJ, [...includeMarkers, 'USJ'], combineTexts);
-		}
-		if (excludeMarkers) {
-			outputUSJ = Filter.remove(outputUSJ, excludeMarkers, combineTexts);
-		}
-
-		return outputUSJ;
-	}
-
-	toList(
-	    excludeMarkers = null,
-	    includeMarkers = null,
-	    ignoreErrors = false,
-	    combineTexts = true
-	) {
-	    /* Uses the toJSON function and converts JSON to CSV
+  toList(
+    excludeMarkers = null,
+    includeMarkers = null,
+    ignoreErrors = false,
+    combineTexts = true
+  ) {
+    /* Uses the toJSON function and converts JSON to CSV
 	       To be re-implemented to work with the flat JSON schema */
 
-	    if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
-	    }
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`
+      );
+    }
 
-	    try {
-	        let excludeList = null;
-	        let includeList = null;
-	    	if (includeMarkers) { 
-	    		includeList = [...includeMarkers, ...Filter.BCV];
-	    	}
-	    	if (excludeMarkers) {
-	    		excludeList = excludeMarkers.filter(item => !Filter.BCV.includes(item));
+    try {
+      let excludeList = null;
+      let includeList = null;
+      if (includeMarkers) {
+        includeList = [...includeMarkers, ...Filter.BCV];
+      }
+      if (excludeMarkers) {
+        excludeList = excludeMarkers.filter(
+          (item) => !Filter.BCV.includes(item)
+        );
+      }
+      const usjDict = this.toUSJ(
+        excludeList,
+        includeList,
+        ignoreErrors,
+        combineTexts
+      );
 
-	    	}
-    		const usjDict = this.toUSJ(excludeList, includeList, ignoreErrors, combineTexts);
+      const listGenerator = new ListGenerator();
+      listGenerator.usjToList(usjDict, excludeMarkers, includeMarkers);
+      return listGenerator.list;
+    } catch (exe) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors.length > 0) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      }
+      throw new Error(message, {cause: exe});
+    }
+  }
 
-	        const listGenerator = new ListGenerator();
-	        listGenerator.usjToList(usjDict, excludeMarkers, includeMarkers);
-	    	return listGenerator.list;
-
-	    } catch (exe) {
-	        let message = "Unable to do the conversion. ";
-	        if (this.errors.length > 0) {
-				let errorString = this.errors.join("\n\t");
-	            message += `Could be due to an error in the USFM\n\t${errorString}`;
-	        }
-	        throw new Error(message, { cause: exe });
-	    }
-
-	}
-
-	toBibleNlpFormat(ignoreErrors = false) {
-	    /* Uses the toUSJ function with only BVC and text.
+  toBibleNlpFormat(ignoreErrors = false) {
+    /* Uses the toUSJ function with only BVC and text.
 	       Then the JSOn is converted to list of verse texts and vrefs*/
 
-	    if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
-	    }
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`
+      );
+    }
 
-	    try {
-	        const usjDict = this.toUSJ(null, [...Filter.BCV, ...Filter.TEXT], ignoreErrors, true);
-	        const listGenerator = new ListGenerator();
-	        listGenerator.usjToBibleNlpFormat(usjDict);
-	    	return listGenerator.bibleNlpFormat;
+    try {
+      const usjDict = this.toUSJ2(
+        null,
+        [...Filter.BCV, ...Filter.TEXT],
+        ignoreErrors,
+        true
+      );
+      const listGenerator = new ListGenerator();
+      listGenerator.usjToBibleNlpFormat(usjDict);
+      return listGenerator.bibleNlpFormat;
+    } catch (exe) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors.length > 0) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      }
+      throw new Error(message, {cause: exe});
+    }
+  }
 
-	    } catch (exe) {
-	        let message = "Unable to do the conversion. ";
-	        if (this.errors.length > 0) {
-				let errorString = this.errors.join("\n\t");
-	            message += `Could be due to an error in the USFM\n\t${errorString}`;
-	        }
-	        throw new Error(message, { cause: exe });
-	    }
+  toUSX(ignoreErrors = false) {
+    /* Convert the syntax_tree to the XML format (USX) */
 
-	}
+    if (!ignoreErrors && this.errors.length > 0) {
+      let errorString = this.errors.join("\n\t");
+      throw new Error(
+        `Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`
+      );
+    }
+    let xmlContent = null;
 
-	toUSX(ignoreErrors = false) {
-	    /* Convert the syntax_tree to the XML format (USX) */
+    try {
+      // Initialize the USX generator (assuming the constructor is already implemented in JS)
+      const usxGenerator = new USXGenerator(USFMParser.language, this.usfm);
 
-	    if (!ignoreErrors && this.errors.length > 0) {
-			let errorString = this.errors.join("\n\t");
-	        throw new Error(`Errors present:\n\t${errorString}\nUse ignoreErrors=true to generate output despite errors`);
-	    }
-	    let xmlContent = null;
+      // Process the syntax tree and convert to USX format
+      usxGenerator.node2Usx(this.syntaxTree, usxGenerator.xmlRootNode);
 
-	    try {
-	        // Initialize the USX generator (assuming the constructor is already implemented in JS)
-	        const usxGenerator = new USXGenerator(USFMParser.language,
-													this.usfm);
-	        
-	        // Process the syntax tree and convert to USX format
-	        usxGenerator.node2Usx(this.syntaxTree, usxGenerator.xmlRootNode);
+      // xmlContent = usxSerializer.serializeToString(usxGenerator.xmlRootNode);
+      xmlContent = usxGenerator.xmlRootNode;
+    } catch (exe) {
+      let message = "Unable to do the conversion. ";
+      if (this.errors.length > 0) {
+        let errorString = this.errors.join("\n\t");
+        message += `Could be due to an error in the USFM\n\t${errorString}`;
+      }
+      throw new Error(message, {cause: exe});
+    }
 
-	        // xmlContent = usxSerializer.serializeToString(usxGenerator.xmlRootNode);
-	        xmlContent = usxGenerator.xmlRootNode;
-	    } catch (exe) {
-	        let message = "Unable to do the conversion. ";
-	        if (this.errors.length > 0) {
-				let errorString = this.errors.join("\n\t");
-	            message += `Could be due to an error in the USFM\n\t${errorString}`;
-	        }
-	        throw new Error(message, { cause: exe });
-	    }
-
-	    // Return the generated XML structure (in JSON format)
-	    return xmlContent;
-	}
-
+    // Return the generated XML structure (in JSON format)
+    return xmlContent;
+  }
 }
 
 export {USFMParser, Filter, ORIGINAL_VREF};

--- a/web-usfm-parser/test.js
+++ b/web-usfm-parser/test.js
@@ -1,42 +1,12 @@
-import {USFMParser} from './src/index.js';
-import { readFile } from 'fs/promises';
-import { DOMParser } from 'xmldom';
+import {USFMParser} from "./src/index.js";
+import {readFile} from "fs/promises";
 
 (async () => {
   await USFMParser.init("tree-sitter-usfm.wasm", "tree-sitter.wasm");
-  // await USFMParser.init();
-  // const usfmParser = new USFMParser('\\id GEN\n\\c 1\n\\p\n\\v 1 In the begining..\\v 2 more text');
-  // const output = usfmParser.toUSJ();
-  // console.log({ output });
-
-  // const usfmParser2 = new USFMParser(null, output);
-  // const output2 = usfmParser.usfm;
-  // console.log({ output2 });
-
-  // const filePath = "../tests/usfmjsTests/missing_verses/origin.usfm";
-  // const content = await readFile(filePath, 'utf-8'); // Specify encoding
-  // console.log(content);
-
-  // await USFMParser.init("tree-sitter-usfm.wasm", "tree-sitter.wasm");
-  // const usfmParser = new USFMParser(content);
-  // const output = usfmParser.toUSJ(null, null, true);
-  // console.log({output})
-  
-  const filePath = "../tests/usfmjsTests/missing_verses/origin.xml";
-  const content = await readFile(filePath, 'utf-8'); // Specify encoding
-  console.log(content);
+  const filePath = "../tests/samples-from-wild/t4t3/origin.usfm";
+  const content = await readFile(filePath, "utf-8"); // Specify encoding
   console.log("*************************");
-
-  const doc = new DOMParser().parseFromString(content);
-  const usfmParser = new USFMParser(null, null, doc);
-  console.log(usfmParser.usfm)
-  console.log("*************************");
-
-  const output = usfmParser.toUSJ(null, null, true);
-  console.log({output})
-  console.log("*************************");
-
-
-
+  const usfmParser = new USFMParser(content);
+  const usj = usfmParser.toUSJ();
+  console.log(usj);
 })();
-

--- a/web-usfm-parser/test.js
+++ b/web-usfm-parser/test.js
@@ -3,10 +3,15 @@ import {readFile} from "fs/promises";
 
 (async () => {
   await USFMParser.init("tree-sitter-usfm.wasm", "tree-sitter.wasm");
-  const filePath = "../tests/samples-from-wild/t4t3/origin.usfm";
+  // const filePath = "../tests/samples-from-wild/t4t3/origin.usfm";
+  const filePath = "../tests/advanced/header/origin.usfm";
   const content = await readFile(filePath, "utf-8"); // Specify encoding
   console.log("*************************");
   const usfmParser = new USFMParser(content);
-  const usj = usfmParser.toUSJ();
-  console.log(usj);
+  // for (let i = 0; i < 100; i++) {
+  //   console.time("toUSJ2");
+  //   const usj = usfmParser.toUSJ2();
+  //   console.timeEnd("toUSJ2");
+  // }
+  // console.log(usj);
 })();

--- a/web-usfm-parser/test/test_usj_conversion.js
+++ b/web-usfm-parser/test/test_usj_conversion.js
@@ -1,53 +1,93 @@
-import assert from 'assert';
-import fs from 'node:fs';
-import Ajv from 'ajv';
-import {allUsfmFiles, initialiseParser, isValidUsfm, excludeUSJs, findAllMarkers} from './config.js';
-import {USFMParser, Filter} from '../src/index.js';
+import assert from "assert";
+import fs from "node:fs";
+import Ajv from "ajv";
+import {
+  allUsfmFiles,
+  initialiseParser,
+  isValidUsfm,
+  excludeUSJs,
+  findAllMarkers,
+} from "./config.js";
+import {USFMParser, Filter} from "../src/index.js";
+
+// Cache for parsed USFM files and their generated USJ to avoid repeated parsing. Not a testing vioaltion cause tests read the same usfm in, and are checking several things against usj out
+const parsedCache = new Map();
+
+// Setup function to populate the cache
+before(async function () {
+  // Increase timeout to handle the parsing of many files
+  this.timeout(90_000); // 90 seconds timeout
+  console.log("Initializing test cache...");
+  const schemaStr = fs.readFileSync("../schemas/usj.js", "utf8");
+  const schema = JSON.parse(schemaStr);
+  parsedCache.set("ajvSchema", schema);
+  for (const filepath of allUsfmFiles) {
+    if (isValidUsfm[filepath]) {
+      try {
+        const parser = await initialiseParser(filepath);
+        const usj = parser.toUSJ2();
+        parsedCache.set(filepath, {
+          parser,
+          usj,
+          usfm: parser.usfm,
+        });
+      } catch (error) {
+        console.error(`Failed to pre-parse ${filepath}: ${error.message}`);
+      }
+    }
+  }
+  console.log(`Cached ${parsedCache.size} USFM files for testing`);
+});
 
 beforeEach(() => {
-    if (global.gc) { global.gc(); }
-  });
+  if (global.gc) {
+    global.gc();
+  }
+});
 
 describe("Check successful USFM-USJ conversion for positive samples", () => {
-  allUsfmFiles.forEach(function(value) {
+  allUsfmFiles.forEach(function (value) {
     if (isValidUsfm[value]) {
-      it(`Convert ${value} to USJ`, async (inputUsfmPath=value) => {
-        const testParser = await initialiseParser(inputUsfmPath)
-        // assert(testParser instanceof USFMParser)
-        const usj = testParser.toUSJ();
-        assert(testParser instanceof Object);
-        assert.strictEqual(usj["type"], "USJ"); 
+      it(`Convert ${value} to USJ`, async (inputUsfmPath = value) => {
+        const cached = parsedCache.get(value);
+        assert(cached, `File ${value} should be in cache`);
+
+        const usj = cached.usj;
+        assert(usj instanceof Object);
+        assert.strictEqual(usj["type"], "USJ");
         assert.strictEqual(usj["version"], "3.1");
-        assert.strictEqual(usj.content[0].type, "book"); 
-        assert.strictEqual(usj.content[0].marker, "id"); 
+        assert.strictEqual(usj.content[0].type, "book");
+        assert.strictEqual(usj.content[0].marker, "id");
       });
     }
   });
 });
 
-
 describe("Compare generated USJ with testsuite sample", () => {
-  allUsfmFiles.forEach(function(value) {
-    const usjPath = value.replace(".usfm", ".json");
-    if (isValidUsfm[value] && ! excludeUSJs.includes(usjPath)) {
-      it(`Compare generated USJ to ${usjPath}`, async (inputUsfmPath=value) => {
-        const testParser = await initialiseParser(inputUsfmPath)
-        const generatedUSJ = testParser.toUSJ();
-        const filePath = usjPath;
+  allUsfmFiles.forEach(function (filepath) {
+    const usjPath = filepath.replace(".usfm", ".json");
+    if (isValidUsfm[filepath] && !excludeUSJs.includes(usjPath)) {
+      it(`Compare generated USJ to ${usjPath}`, function () {
+        const cached = parsedCache.get(filepath);
+        assert(cached, `File ${filepath} should be in cache`);
         let fileData = null;
         try {
-          fileData = fs.readFileSync(filePath, "utf8");
-        } catch(err) {
+          fileData = fs.readFileSync(usjPath, "utf8");
+        } catch (err) {
           if (err.code === "ENOENT") {
-            return
+            this.skip();
           }
+          throw err;
         }
+
+        const generatedUSJ = JSON.parse(JSON.stringify(cached.usj)); // Deep clone to avoid modifying cached object
         const testsuiteUSJ = JSON.parse(fileData);
-        stripDefaultAttribValue(testsuiteUSJ)
-        removeNewlinesInText(testsuiteUSJ)
-        stripTextValue(testsuiteUSJ)
-        removeNewlinesInText(generatedUSJ)
-        stripTextValue(generatedUSJ)
+
+        stripDefaultAttribValue(testsuiteUSJ);
+        removeNewlinesInText(testsuiteUSJ);
+        stripTextValue(testsuiteUSJ);
+        removeNewlinesInText(generatedUSJ);
+        stripTextValue(generatedUSJ);
 
         assert.deepEqual(generatedUSJ, testsuiteUSJ);
       });
@@ -55,246 +95,264 @@ describe("Compare generated USJ with testsuite sample", () => {
   });
 });
 
-
 describe("Test USFM-USJ-USFM roundtripping", () => {
-  allUsfmFiles.forEach(function(value) {
-    if (isValidUsfm[value]) {
-      it(`Roundtrip ${value} via USJ`, async (inputUsfmPath=value) => {
-        const testParser = await initialiseParser(inputUsfmPath)
-        assert(testParser instanceof USFMParser)
-        const usj = testParser.toUSJ();
-        assert(usj instanceof Object);
-    
+  allUsfmFiles.forEach(function (filepath) {
+    if (isValidUsfm[filepath]) {
+      it(`Roundtrip ${filepath} via USJ`, function () {
+        const cached = parsedCache.get(filepath);
+        assert(cached, `File ${filepath} should be in cache`);
+
+        const usj = cached.usj;
+        const originalUsfm = cached.usfm;
+
         const testParser2 = new USFMParser(null, usj);
         const generatedUSFM = testParser2.usfm;
-        assert.strictEqual(typeof generatedUSFM, 'string');
+
+        assert.strictEqual(typeof generatedUSFM, "string");
         assert(generatedUSFM.startsWith("\\id"));
 
-        const inputMarkers = findAllMarkers(testParser.usfm)
-        const finalMarkers = findAllMarkers(generatedUSFM)
-        assert.deepStrictEqual(inputMarkers, finalMarkers, `Markers in input and generated USFMs differ`)
+        const inputMarkers = findAllMarkers(originalUsfm);
+        const finalMarkers = findAllMarkers(generatedUSFM);
 
-
-
+        assert.deepStrictEqual(
+          inputMarkers,
+          finalMarkers,
+          `Markers in input and generated USFMs differ`
+        );
       });
     }
   });
-
 });
 
-
 describe("Ensure all markers are in USJ", () => {
-  // Tests if all markers in USFM are present in output also
-  allUsfmFiles.forEach(function(value) {
-    if (isValidUsfm[value]) {
-      it(`Check for markers of ${value} in USJ`, async (inputUsfmPath=value) => {
-        const testParser = await initialiseParser(inputUsfmPath)
-        assert(testParser instanceof USFMParser)
-        const usj = testParser.toUSJ();
-        assert(usj instanceof Object);
+  allUsfmFiles.forEach(function (filepath) {
+    if (isValidUsfm[filepath]) {
+      it(`Check for markers of ${filepath} in USJ`, function () {
+        const cached = parsedCache.get(filepath);
+        assert(cached, `File ${filepath} should be in cache`);
 
-        const inputMarkers = [... new Set(findAllMarkers(testParser.usfm, true))]
+        const usj = cached.usj;
+        const originalUsfm = cached.usfm;
+
+        const inputMarkers = [...new Set(findAllMarkers(originalUsfm, true))];
         const allUSJTypes = getTypes(usj);
 
-        assert.deepStrictEqual(inputMarkers, allUSJTypes, `Markers in input and generated USJ differ`)
+        assert.deepStrictEqual(
+          inputMarkers,
+          allUSJTypes,
+          `Markers in input and generated USJ differ`
+        );
       });
     }
   });
-
 });
 
 describe("Validate USJ against schema", () => {
   // Test generated USJ against USJ schema
+  // const ajv = new Ajv();
+  // const schemaStr = fs.readFileSync("../schemas/usj.js", "utf8");
   const ajv = new Ajv();
-  const schemaStr = fs.readFileSync("../schemas/usj.js", 'utf8');
-  const schema = JSON.parse(schemaStr);
+  const schema = parsedCache;
   const validate = ajv.compile(schema);
 
-  allUsfmFiles.forEach(function(value) {
+  allUsfmFiles.forEach(function (value) {
     if (isValidUsfm[value]) {
-      it(`Validate USJ generated from ${value}`, async (inputUsfmPath=value) => {
-        const testParser = await initialiseParser(inputUsfmPath)
-        assert(testParser instanceof USFMParser)
-        const usj = testParser.toUSJ();
-        assert(usj instanceof Object);
+      it(`Validate USJ generated from ${value}`, async () => {
+        const cached = parsedCache.get(value);
+        assert(cached, `File ${value} should be in cache`);
 
-        assert(validate(usj));  
-
+        const usj = cached.usj;
+        assert(validate(usj), JSON.stringify(validate.errors, null, 2));
       });
     }
   });
-
 });
 
 describe("Test Exclude Marker option", () => {
-    // Test Exclude Maker option by checking markers in the USJ
-      const excludeTests = [
-            ['v', 'c'],
-            Filter.PARAGRAPHS,
-            [...Filter.TITLES, ...Filter.BOOK_HEADERS ]
-        ]
-    excludeTests.forEach(function(exList) {
-        allUsfmFiles.forEach(function(value) {
-          if (isValidUsfm[value]) {
-            it(`Exclude ${exList.slice(0, 5)} from ${value}`, async (inputUsfmPath=value) => {
-                const testParser = await initialiseParser(inputUsfmPath)
-                assert(testParser instanceof USFMParser)
-                const usj = testParser.toUSJ(exList);
-                assert(usj instanceof Object);
+  // Test Exclude Maker option by checking markers in the USJ
+  const excludeTests = [
+    ["v", "c"],
+    Filter.PARAGRAPHS,
+    [...Filter.TITLES, ...Filter.BOOK_HEADERS],
+  ];
+  excludeTests.forEach(function (exList) {
+    allUsfmFiles.forEach(function (filepath) {
+      if (isValidUsfm[filepath]) {
+        it(`Exclude ${exList.slice(0, 5)} from ${filepath}`, async function () {
+          const cached = parsedCache.get(filepath);
+          assert(cached, `File ${filepath} should be in cache`);
 
-                const allUSJTypes = getTypes(usj)
-                let types = new Set(allUSJTypes);
-                let intersection = exList.filter(value => types.has(value));
-                assert.deepStrictEqual(intersection, [])
-            });
-          }
-        })
-    })
+          // For exclude tests, we need to regenerate the USJ with specific options
+          const parser = cached.parser;
+          const usj = parser.toUSJ2(exList);
+
+          const allUSJTypes = getTypes(usj);
+          let types = new Set(allUSJTypes);
+          let intersection = exList.filter((value) => types.has(value));
+          assert.deepStrictEqual(intersection, []);
+        });
+      }
+    });
+  });
 });
 
 describe("Test Include Marker option", () => {
-    // Test Include Maker option by checking markers in the USJ
-      const includeTests = [
-            ['v', 'c'],
-            Filter.PARAGRAPHS,
-            [...Filter.TITLES, ...Filter.BOOK_HEADERS ]
-        ]
-    includeTests.forEach(function(inList) {
-        allUsfmFiles.forEach(function(value) {
-          if (isValidUsfm[value]) {
-            it(`Include ${inList.slice(0, 5)} in ${value}`, async (inputUsfmPath=value) => {
-                const testParser = await initialiseParser(inputUsfmPath)
-                assert(testParser instanceof USFMParser)
-                const usj = testParser.toUSJ(null, inList);
-                assert(usj instanceof Object);
+  const includeTests = [
+    ["v", "c"],
+    Filter.PARAGRAPHS,
+    [...Filter.TITLES, ...Filter.BOOK_HEADERS],
+  ];
 
-                let allUSJTypes = getTypes(usj, false)
-                assert( allUSJTypes.every(element => inList.includes(element)), allUSJTypes)
-            });
-          }
-        })
-    })
+  includeTests.forEach(function (inList) {
+    allUsfmFiles.forEach(function (filepath) {
+      if (isValidUsfm[filepath]) {
+        it(`Include ${inList.slice(0, 5)} in ${filepath}`, async function () {
+          const cached = parsedCache.get(filepath);
+          assert(cached, `File ${filepath} should be in cache`);
+
+          // For include tests, we need to regenerate the USJ with specific options
+          const parser = cached.parser;
+          const usj = parser.toUSJ2(null, inList);
+
+          let allUSJTypes = getTypes(usj, false);
+          assert(
+            allUSJTypes.every((element) => inList.includes(element)),
+            allUSJTypes
+          );
+        });
+      }
+    });
+  });
 });
 
 describe("Try invalid USJ", () => {
-    it("without type",  async () => {
-        const usj = {"some key":"qwerty", "content": []};
-        try {
-            const testParser = new USFMParser(null, usj);
-        } catch(err) {
-            assert.strictEqual("Invalid input for USJ. Expected USJ json object.", err.message)
-        }
-    });
+  it("without type", async () => {
+    const usj = {"some key": "qwerty", content: []};
+    try {
+      const testParser = new USFMParser(null, usj);
+    } catch (err) {
+      assert.strictEqual(
+        "Invalid input for USJ. Expected USJ json object.",
+        err.message
+      );
+    }
+  });
 
-    it("interger", () => {
-        const usj = {"type":"para", "content": [1, 2, 3]};
-        try {
-            const testParser = new USFMParser(null, usj);
-        } catch(err) {
-            assert.strictEqual("Invalid input for USJ. Expected USJ json object.", err.message)
-        }
-    });
+  it("interger", () => {
+    const usj = {type: "para", content: [1, 2, 3]};
+    try {
+      const testParser = new USFMParser(null, usj);
+    } catch (err) {
+      assert.strictEqual(
+        "Invalid input for USJ. Expected USJ json object.",
+        err.message
+      );
+    }
+  });
 
-    it("content with array", () => {
-        const usj = {"some key":"qwerty", "content": [["test", "test", "test"]]};
-        try {
-            const testParser = new USFMParser(null, usj);
-        } catch(err) {
-            assert.strictEqual("Invalid input for USJ. Expected USJ json object.", err.message)
-        }
-    });
-
+  it("content with array", () => {
+    const usj = {"some key": "qwerty", content: [["test", "test", "test"]]};
+    try {
+      const testParser = new USFMParser(null, usj);
+    } catch (err) {
+      assert.strictEqual(
+        "Invalid input for USJ. Expected USJ json object.",
+        err.message
+      );
+    }
+  });
 });
 
 function stripTextValue(usjObj) {
-    /* Trailing and preceding space handling can be different between tcdocs and our logic.
+  /* Trailing and preceding space handling can be different between tcdocs and our logic.
        Strip both before comparison */
-    if (usjObj.hasOwnProperty("content")) {
-        usjObj["content"].forEach((item, index) => {
-            if (typeof item === 'string') {
-                usjObj["content"][index] = item.trim();  // Strip spaces from strings
-            } else {
-                stripTextValue(item);  // Recursively handle nested objects
-            }
-        });
-    }
+  if (usjObj.hasOwnProperty("content")) {
+    usjObj["content"].forEach((item, index) => {
+      if (typeof item === "string") {
+        usjObj["content"][index] = item.trim(); // Strip spaces from strings
+      } else {
+        stripTextValue(item); // Recursively handle nested objects
+      }
+    });
+  }
 }
 
 function removeNewlinesInText(usjDict) {
-    /* The test samples in testsuite do not preserve new lines. But we do in usfm-grammar.
+  /* The test samples in testsuite do not preserve new lines. But we do in usfm-grammar.
        So removing them just for comparison */
-    if (usjDict.hasOwnProperty("content")) {
-        usjDict["content"].forEach((item, index) => {
-            if (typeof item === 'string') {
-                // Replace newlines with spaces
-                usjDict["content"][index] = item.replace(/\n/g, " ");
-                // Replace multiple spaces with a single space
-                usjDict["content"][index] = usjDict["content"][index].replace(/\s+/g, " ");
-            } else {
-                removeNewlinesInText(item);  // Recursively handle nested dictionaries
-            }
-        });
-        // there will be difference in number of white space only text snippets
-        usjDict['content'] = usjDict['content'].filter(item => item === "")
-
-    }
+  if (usjDict.hasOwnProperty("content")) {
+    usjDict["content"].forEach((item, index) => {
+      if (typeof item === "string") {
+        // Replace newlines with spaces
+        usjDict["content"][index] = item.replace(/\n/g, " ");
+        // Replace multiple spaces with a single space
+        usjDict["content"][index] = usjDict["content"][index].replace(
+          /\s+/g,
+          " "
+        );
+      } else {
+        removeNewlinesInText(item); // Recursively handle nested dictionaries
+      }
+    });
+    // there will be difference in number of white space only text snippets
+    usjDict["content"] = usjDict["content"].filter((item) => item === "");
+  }
 }
-
 
 function stripDefaultAttribValue(usjDict) {
-    /* The USX samples in test suite have space in lemma values when given as default attribute */
-    if (usjDict.hasOwnProperty("content")) {
-        usjDict["content"].forEach(item => {
-            if (typeof item === 'object' && !Array.isArray(item)) {
-                if (item["type"] === "char" && item["marker"] === "w") {
-                    if (item.hasOwnProperty("lemma")) {
-                        item["lemma"] = item["lemma"].trim();  // Strip spaces from 'lemma'
-                    }
-                }
-                stripDefaultAttribValue(item);  // Recursively handle nested dictionaries
-            }
-        });
-    }
+  /* The USX samples in test suite have space in lemma values when given as default attribute */
+  if (usjDict.hasOwnProperty("content")) {
+    usjDict["content"].forEach((item) => {
+      if (typeof item === "object" && !Array.isArray(item)) {
+        if (item["type"] === "char" && item["marker"] === "w") {
+          if (item.hasOwnProperty("lemma")) {
+            item["lemma"] = item["lemma"].trim(); // Strip spaces from 'lemma'
+          }
+        }
+        stripDefaultAttribValue(item); // Recursively handle nested dictionaries
+      }
+    });
+  }
 }
 
-function getTypes(element, keepNumber=true) {
-    // Recursive function to find all keys in the dict output
-    let types = [];
-    if (typeof element === 'string') {
-        return types; // Return empty array if element is a string
-    } else {
-        if ('marker' in element) {
-            types.push(element.marker);
-        }
-        if (element.type === 'ref') {
-            types.push("ref");
-        }
-        if ('altnumber' in element) {
-            if (element.marker === 'c') {
-                types.push('ca');
-            } else {
-                types.push('va');
-            }
-        }
-        if ('pubnumber' in element) {
-            if (element.marker === 'c') {
-                types.push('cp');
-            } else {
-                types.push('vp');
-            }
-        }
-        if ('category' in element) {
-            types.push('cat');
-        }
-        if ('content' in element) {
-            element.content.forEach(item => {
-                types = types.concat(getTypes(item)); // Recursively get types from content
-            });
-        }
+function getTypes(element, keepNumber = true) {
+  // Recursive function to find all keys in the dict output
+  let types = [];
+  if (typeof element === "string") {
+    return types; // Return empty array if element is a string
+  } else {
+    if ("marker" in element) {
+      types.push(element.marker);
     }
-    let uniqueTypes = [...new Set(types)];
-    if (! keepNumber) {
-        uniqueTypes = uniqueTypes.map(item => item.replace(/\d+$/, ''));
-    }    
-    return uniqueTypes;
+    if (element.type === "ref") {
+      types.push("ref");
+    }
+    if ("altnumber" in element) {
+      if (element.marker === "c") {
+        types.push("ca");
+      } else {
+        types.push("va");
+      }
+    }
+    if ("pubnumber" in element) {
+      if (element.marker === "c") {
+        types.push("cp");
+      } else {
+        types.push("vp");
+      }
+    }
+    if ("category" in element) {
+      types.push("cat");
+    }
+    if ("content" in element) {
+      element.content.forEach((item) => {
+        types = types.concat(getTypes(item)); // Recursively get types from content
+      });
+    }
+  }
+  let uniqueTypes = [...new Set(types)];
+  if (!keepNumber) {
+    uniqueTypes = uniqueTypes.map((item) => item.replace(/\d+$/, ""));
+  }
+  return uniqueTypes;
 }


### PR DESCRIPTION
I cleaned up the web usj generation I previously had started in the prior pr.  I also took the same approach to the USX, and perhaps against my better judgement, realized it seemed like the USX wasn't generating proper usx in some cases. Mostly notably, there was an opening but no closing chapter tags in the usx like there were for the verses. Maybe related is #326 :   I changed this behavior so that chapters closed as well.    Both usx and usj now benchmark between 8 and about 20 ms on average on my computer from the shortest of test cases to the longest.  I mostly wanted to get this in cause I didn't want to keep this feature branch just hanging out for too long while any other work was being done.
if y'all test and decide that you're happy with both: 
1. The tests passing spec compliance of both the USJ and USX changes
2. The speed / current shape of the api

Then I think the next sensible think there's quite a few sensible next steps I could maybe help with. 
1. For the JS stuff, it'd be worth having a conversation around unifying to one package.  This could mean running wasm on Node, or more likley, we can keep the ndoe bindings but move all the js into one folder and use package.json exports conditions to generate multiple clients: 
2. The python package probably needs a refactor for speed as well I'd imagine if it follow the way everything had currently been built. I could either look at refactoring it, or y'all could just shape it according this pr to keep everything consistent. 
3. TS types would be nice, especially since there's a few weird spots of passing null parameters and what not. A more typical JS pattern I think would have been to pass a single config object, but those would be breaking changes to be discussed. 

Let me know if y'all have any questions or else I can help with.