### PR TITLE
Bugfix/verse in table cell

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.1
+current_version = 3.1.2
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\-(?P<release>\w+)\.(?P<num>\d+))?

--- a/node-usfm-parser/package.json
+++ b/node-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CSV, and converts them back to USFM",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/es/index.mjs",
@@ -28,7 +28,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "tree-sitter": "0.21.1",
-    "tree-sitter-usfm3": "3.1.1",
+    "tree-sitter-usfm3": "3.1.2",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
   },

--- a/node-usfm-parser/src/usxGenerator.js
+++ b/node-usfm-parser/src/usxGenerator.js
@@ -27,6 +27,11 @@ class USXGenerator {
         } else {
             this.xmlRootNode = usxRootElement;
         }
+
+        this.parseState = {
+            prevVerseSid: null,
+            prevVerseParent: null
+        }
     }
 
     /**
@@ -138,56 +143,14 @@ class USXGenerator {
 
 	}
 
-	findPrevUncle(parentXmlNode) {
-        // Get the grandparent node
-        const grandParent = parentXmlNode.parentNode;
-        let uncleIndex = grandParent.childNodes.length - 2; // Start from the previous sibling
-
-        while (uncleIndex >= 0) {
-            const uncle = grandParent.childNodes[uncleIndex];
-
-            // Skip 'sidebar' and 'ms' elements
-            if (uncle.tagName === "sidebar" || uncle.tagName === "ms") {
-                uncleIndex--;
-            }
-            // Skip elements with 'ca' or 'cp' in the style attribute
-            else if (uncle.getAttribute('style') === 'ca' || uncle.getAttribute('style') === 'cp') {
-                uncleIndex--;
-            }
-            // Return the found uncle element
-            else {
-                return uncle;
-            }
-        }
-        return null;  // No suitable uncle found
-    }
-
     node2UsxVerse(node, parentXmlNode) {
-        // Find all previous 'verse' elements
-        const prevVerses = xpath.select("//verse", this.xmlRootNode);
 
-        // Check if there are previous verses and if the last one has a 'sid' attribute
-        if (prevVerses.length > 0 && prevVerses[prevVerses.length - 1].hasAttribute('sid')) {
-            let vEndXmlNode;
-            if (parentXmlNode.textContent.trim() !== "") {
-                // If there is verse text in the current parent
-                vEndXmlNode = parentXmlNode.ownerDocument.createElement('verse');
-                parentXmlNode.appendChild(vEndXmlNode);
-            } else {
-                // If no text, find the previous uncle and attach the end verse
-                const prevUncle = this.findPrevUncle(parentXmlNode);
-                if (prevUncle.tagName === "para") {
-                    vEndXmlNode = prevUncle.ownerDocument.createElement('verse');
-                    prevUncle.appendChild(vEndXmlNode);
-                } else if (prevUncle.tagName === "table") {
-                    const rows = prevUncle.getElementsByTagName('row');
-                    vEndXmlNode = prevUncle.ownerDocument.createElement('verse');
-                    rows[rows.length - 1].appendChild(vEndXmlNode);
-                } else {
-                    throw new Error(`prev_uncle is ${String(prevUncle)}`);
-                }
-            }
-            vEndXmlNode.setAttribute('eid', prevVerses[prevVerses.length - 1].getAttribute('sid'));
+        // Check if there are previous verses to close
+        if (this.parseState.prevVerseSid !== null) {
+            let prevPara = this.parseState.prevVerseParent;
+            let vEndXmlNode = prevPara.ownerDocument.createElement('verse');
+            vEndXmlNode.setAttribute("eid", this.parseState.prevVerseSid);
+            prevPara.appendChild(vEndXmlNode);
         }
 
         // Query to capture verse-related elements

--- a/py-usfm-parser/pyproject.toml
+++ b/py-usfm-parser/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "usfm-grammar"
-version = "3.1.1"
+version = "3.1.2"
 description = "Python parser for USFM files, based on tree-sitter-usfm3"
 readme = "README.md"
 authors = [{ name = "BCS Team", email = "joel@bridgeconn.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["usfm", "parser", "grammar", "tree-sitter"]
 dependencies = [
     'tree-sitter==0.22.3; python_version >= "3.9"',
-    'tree-sitter-usfm3==3.1.1; python_version >="3.8"',
+    'tree-sitter-usfm3==3.1.2; python_version >="3.8"',
     'lxml==5.2.2; python_version >= "3.5"',
     'jsonschema==4.23.0; python_version>= "3.8"'
 ]

--- a/py-usfm-parser/requirements.txt
+++ b/py-usfm-parser/requirements.txt
@@ -1,4 +1,4 @@
 tree-sitter==0.22.3
-tree-sitter-usfm3==3.1.1
+tree-sitter-usfm3==3.1.2
 lxml==5.2.2
 jsonschema==4.23.0

--- a/py-usfm-parser/setup.py
+++ b/py-usfm-parser/setup.py
@@ -7,7 +7,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="usfm-grammar",  # Required
-    version="3.1.1",  # Required
+    version="3.1.2",  # Required
     python_requires=">=3.10",
     # install_requires=["tree-sitter==0.22.3",
                         # "tree-sitter-usfm3==3.0.0-beta.7",  

--- a/py-usfm-parser/src/usfm_grammar/__init__.py
+++ b/py-usfm-parser/src/usfm_grammar/__init__.py
@@ -11,4 +11,4 @@ USFMParser = usfm_parser.USFMParser
 Validator = validator.Validator
 ORIGINAL_VREF = vrefs.original_vref
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"

--- a/py-usfm-parser/src/usfm_grammar/usx_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usx_generator.py
@@ -140,7 +140,7 @@ class USXGenerator:
         v_xml_node.set('number', verse_num.strip())
         v_xml_node.set('style', "v")
         v_xml_node.set('sid', ref.strip())
-        self.parse_state["prev_verse_sid"] = 
+        self.parse_state["prev_verse_sid"] = sid
 
     def node_2_usx_ca_va(self, node, parent_xml_node):
         '''Build elements for independant ca and va away from c and v'''

--- a/py-usfm-parser/src/usfm_grammar/usx_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usx_generator.py
@@ -113,9 +113,13 @@ class USXGenerator:
         grand_parent = parent_xml_node.getparent()
         uncle_index = -2
         while True:
+            while len(grand_parent.getchildren()) < abs(uncle_index):
+                grand_uncle = self.find_prev_uncle(grand_parent)
+                grand_parent = grand_uncle
+                uncle_index = -1
             if grand_parent[uncle_index].tag in ["sidebar", "ms"]:
                 uncle_index -= 1
-            elif grand_parent[uncle_index].get('style') in ['ca', 'cp']:
+            elif grand_parent[uncle_index].get('style') in ['ca', 'cp', 'b']:
                 uncle_index -= 1
             else:
                 prev_uncle = grand_parent[uncle_index]
@@ -131,13 +135,14 @@ class USXGenerator:
                 v_end_xml_node = etree.SubElement(parent_xml_node, "verse")
             else:
                 prev_uncle = self.find_prev_uncle(parent_xml_node)
-                if prev_uncle.tag == "para":
+                if prev_uncle.tag in ["para", "cell"]:
                     v_end_xml_node = etree.SubElement(prev_uncle, "verse")
                 elif prev_uncle.tag == "table":
-                    rows = list(prev_uncle)
-                    v_end_xml_node = etree.SubElement(rows[-1], "verse")
+                    rows = prev_uncle.getchildren()
+                    last_cell = rows[-1].getchildren()[-1]
+                    v_end_xml_node = etree.SubElement(last_cell, "verse")
                 else:
-                    raise Exception(" prev_uncle is "+str(prev_uncle))
+                    raise Exception(" prev_uncle is "+prev_uncle.tag)
             v_end_xml_node.set('eid', prev_verses[-1].get('sid'))
         verse_num_cap = self.usfm_language.query('''
                                 (v

--- a/py-usfm-parser/src/usfm_grammar/usx_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usx_generator.py
@@ -116,7 +116,7 @@ class USXGenerator:
         '''build verse node in USX'''
         eid = self.parse_state["prev_verse_sid"]
         if eid is not None:
-            prev_para = self.prev_verse_parent
+            prev_para = self.parse_state["prev_verse_parent"]
             v_end_xml_node = etree.SubElement(prev_para, "verse")
             v_end_xml_node.set('eid', eid)
         verse_num_cap = self.usfm_language.query('''
@@ -330,7 +330,7 @@ class USXGenerator:
         elif node.type == "verseText":
             for child in node.children:
                 self.node_2_usx(child, parent_xml_node)
-            self.prev_verse_parent = parent_xml_node
+            self.parse_state["prev_verse_parent"] = parent_xml_node
         elif node.type in ['paragraph', 'pi', "ph"]:
             self.node_2_usx_para(node, parent_xml_node)
         elif node.type in self.NOTE_MARKERS:

--- a/py-usfm-parser/src/usfm_grammar/usx_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usx_generator.py
@@ -43,6 +43,10 @@ class USXGenerator:
             self.xml_root_node.set("version", "3.1")
         else:
             self.xml_root_node = usx_root_element
+        self.parse_state = {
+            "prev_verse_parent": None,
+            "prev_verse_sid": None,
+        }
 
     def node_2_usx_id(self, node, parent_xml_node):
         '''build id node in USX'''
@@ -108,42 +112,13 @@ class USXGenerator:
         chap_end_xml_node = etree.SubElement(parent_xml_node, "chapter")
         chap_end_xml_node.set("eid", chap_ref)
 
-    def find_prev_uncle(self, parent_xml_node):
-        '''To find the ealier sibling of the current parent to attach the verse end node'''
-        grand_parent = parent_xml_node.getparent()
-        uncle_index = -2
-        while True:
-            while len(grand_parent.getchildren()) < abs(uncle_index):
-                grand_uncle = self.find_prev_uncle(grand_parent)
-                grand_parent = grand_uncle
-                uncle_index = -1
-            if grand_parent[uncle_index].tag in ["sidebar", "ms"]:
-                uncle_index -= 1
-            elif grand_parent[uncle_index].get('style') in ['ca', 'cp', 'b']:
-                uncle_index -= 1
-            else:
-                prev_uncle = grand_parent[uncle_index]
-                return prev_uncle
-        return None
-
     def node_2_usx_verse(self, node, parent_xml_node):
         '''build verse node in USX'''
-        prev_verses = self.xml_root_node.findall(".//verse")
-        if len(prev_verses)>0 and "sid" in prev_verses[-1].attrib:
-            if ''.join(parent_xml_node.itertext()) != "":
-                # if there is verse text in this parent
-                v_end_xml_node = etree.SubElement(parent_xml_node, "verse")
-            else:
-                prev_uncle = self.find_prev_uncle(parent_xml_node)
-                if prev_uncle.tag in ["para", "cell"]:
-                    v_end_xml_node = etree.SubElement(prev_uncle, "verse")
-                elif prev_uncle.tag == "table":
-                    rows = prev_uncle.getchildren()
-                    last_cell = rows[-1].getchildren()[-1]
-                    v_end_xml_node = etree.SubElement(last_cell, "verse")
-                else:
-                    raise Exception(" prev_uncle is "+prev_uncle.tag)
-            v_end_xml_node.set('eid', prev_verses[-1].get('sid'))
+        eid = self.parse_state["prev_verse_sid"]
+        if eid is not None:
+            prev_para = self.prev_verse_parent
+            v_end_xml_node = etree.SubElement(prev_para, "verse")
+            v_end_xml_node.set('eid', eid)
         verse_num_cap = self.usfm_language.query('''
                                 (v
                                     (verseNumber) @vnum
@@ -161,9 +136,11 @@ class USXGenerator:
                 vp_text = self.usfm[tupl[0].start_byte:tupl[0].end_byte].decode('utf-8')
                 v_xml_node.set('pubnumber', vp_text.strip())
         ref = self.xml_root_node.findall('.//chapter')[-1].get('sid')+ ":"+ verse_num
+        sid = ref.strip()
         v_xml_node.set('number', verse_num.strip())
         v_xml_node.set('style', "v")
         v_xml_node.set('sid', ref.strip())
+        self.parse_state["prev_verse_sid"] = 
 
     def node_2_usx_ca_va(self, node, parent_xml_node):
         '''Build elements for independant ca and va away from c and v'''
@@ -353,6 +330,7 @@ class USXGenerator:
         elif node.type == "verseText":
             for child in node.children:
                 self.node_2_usx(child, parent_xml_node)
+            self.prev_verse_parent = parent_xml_node
         elif node.type in ['paragraph', 'pi', "ph"]:
             self.node_2_usx_para(node, parent_xml_node)
         elif node.type in self.NOTE_MARKERS:

--- a/tests/bugfixes/empty-table-cell/metadata.xml
+++ b/tests/bugfixes/empty-table-cell/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-metadata>
+        <description>Table cells are seen left empty. Also the \v usage was not supported in table cells before in USFM-Grammar. https://github.com/Bridgeconn/usfm-grammar/issues/326 </description>
+        <validated>pass</validated>
+        <tags></tags>
+</test-metadata>

--- a/tests/bugfixes/empty-table-cell/origin.json
+++ b/tests/bugfixes/empty-table-cell/origin.json
@@ -1,0 +1,186 @@
+{
+    "type": "USJ",
+    "version": "3.1",
+    "content": [
+        {
+            "type": "book",
+            "marker": "id",
+            "content": [],
+            "code": "GEN"
+        },
+        {
+            "type": "chapter",
+            "marker": "c",
+            "number": "1",
+            "sid": "GEN 1"
+        },
+        {
+            "type": "para",
+            "marker": "p",
+            "content": [
+                {
+                    "type": "verse",
+                    "marker": "v",
+                    "number": "8",
+                    "sid": "GEN 1:8"
+                },
+                "Sairos king a Porzha sen fi dem wid Michredat di chrezha man, an im kount dem op an gi dem tu Sheshbazaar, di liida fi Juuda.\n"
+            ]
+        },
+        {
+            "type": "para",
+            "marker": "p",
+            "content": [
+                {
+                    "type": "verse",
+                    "marker": "v",
+                    "number": "9",
+                    "sid": "GEN 1:9"
+                },
+                "Dis a aal a we dem did fi inchaaj a: 30 guol boul, 1,000 silva boul, 29 silva pan,\n"
+            ]
+        },
+        {
+            "type": "para",
+            "marker": "b"
+        },
+        {
+            "type": "table",
+            "content": [
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr2",
+                            "content": [],
+                            "align": "end"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr2",
+                            "content": [],
+                            "align": "end"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr2",
+                            "content": [],
+                            "align": "end"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [
+                                {
+                                    "type": "verse",
+                                    "marker": "v",
+                                    "number": "10",
+                                    "sid": "GEN 1:10"
+                                },
+                                "guol boul 30, silva boul 410 an di res a tingz dem, 1,000, "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr2",
+                            "content": [],
+                            "align": "end"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr2",
+                            "content": [],
+                            "align": "end"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr2",
+                            "content": [],
+                            "align": "end"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "para",
+            "marker": "b"
+        },
+        {
+            "type": "para",
+            "marker": "p",
+            "content": [
+                {
+                    "type": "verse",
+                    "marker": "v",
+                    "number": "11",
+                    "sid": "GEN 1:11"
+                },
+                "In aal, yu did av 5,400 guol an silva juulri an tingz. Sheshbazaar did bring aal a dem ya wid im wen di piipl dem we a get kyapcha kom bak a Jeruusilem fram Babilan.\n"
+            ]
+        }
+    ]
+}

--- a/tests/bugfixes/empty-table-cell/origin.usfm
+++ b/tests/bugfixes/empty-table-cell/origin.usfm
@@ -1,0 +1,17 @@
+\id GEN
+\c 1
+\p
+\v 8 Sairos king a Porzha sen fi dem wid Michredat di chrezha man, an im kount dem op an gi dem tu Sheshbazaar, di liida fi Juuda.
+\p
+\v 9 Dis a aal a we dem did fi inchaaj a: 30 guol boul, 1,000 silva boul, 29 silva pan,
+\b
+\tr \tc1 \tcr2
+\tr \tc1 \tcr2
+\tr \tc1 \tcr2
+\tr \tc1
+\v 10 guol boul 30, silva boul 410 an di res a tingz dem, 1,000, \tcr2
+\tr \tc1 \tcr2
+\tr \tc1 \tcr2
+\b
+\p
+\v 11 In aal, yu did av 5,400 guol an silva juulri an tingz. Sheshbazaar did bring aal a dem ya wid im wen di piipl dem we a get kyapcha kom bak a Jeruusilem fram Babilan.

--- a/tests/bugfixes/empty-table-cell/origin.usfm
+++ b/tests/bugfixes/empty-table-cell/origin.usfm
@@ -5,8 +5,8 @@
 \p
 \v 9 Dis a aal a we dem did fi inchaaj a: 30 guol boul, 1,000 silva boul, 29 silva pan,
 \b
-\tr \tc1 \tcr2
-\tr \tc1 \tcr2
+\tr \tc1 \v 9a test test test \tcr2
+\tr \tc1 \tcr2 \v 9b test again
 \tr \tc1 \tcr2
 \tr \tc1
 \v 10 guol boul 30, silva boul 410 an di res a tingz dem, 1,000, \tcr2

--- a/tests/bugfixes/empty-table-cell/origin.xml
+++ b/tests/bugfixes/empty-table-cell/origin.xml
@@ -1,0 +1,41 @@
+<usx version="3.1">
+  <book code="GEN" style="id"/>
+  <chapter number="1" style="c" sid="GEN 1"/>
+  <para style="p"><verse number="8" style="v" sid="GEN 1:8"/>Sairos king a Porzha sen fi dem wid Michredat di chrezha man, an im kount dem op an gi dem tu Sheshbazaar, di liida fi Juuda.
+<verse eid="GEN 1:8"/></para>
+  <para style="p"><verse number="9" style="v" sid="GEN 1:9"/>Dis a aal a we dem did fi inchaaj a: 30 guol boul, 1,000 silva boul, 29 silva pan,
+<verse eid="GEN 1:9"/></para>
+  <para style="b"/>
+  <table>
+    <row style="tr">
+      <cell style="tc1" align="start"><verse number="9a" style="v" sid="GEN 1:9a"/>test test test <verse eid="GEN 1:9a"/></cell>
+      <cell style="tcr2" align="end"/>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start"/>
+      <cell style="tcr2" align="end"><verse number="9b" style="v" sid="GEN 1:9b"/>test again
+<verse eid="GEN 1:9b"/></cell>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start"/>
+      <cell style="tcr2" align="end"/>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start"><verse number="10" style="v" sid="GEN 1:10"/>guol boul 30, silva boul 410 an di res a tingz dem, 1,000, <verse eid="GEN 1:10"/></cell>
+      <cell style="tcr2" align="end"/>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start"/>
+      <cell style="tcr2" align="end"/>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start"/>
+      <cell style="tcr2" align="end"/>
+    </row>
+  </table>
+  <para style="b"/>
+  <para style="p"><verse number="11" style="v" sid="GEN 1:11"/>In aal, yu did av 5,400 guol an silva juulri an tingz. Sheshbazaar did bring aal a dem ya wid im wen di piipl dem we a get kyapcha kom bak a Jeruusilem fram Babilan.
+<verse eid="GEN 1:11"/></para>
+  <chapter eid="GEN 1"/>
+</usx>
+

--- a/tree-sitter-usfm3/grammar.js
+++ b/tree-sitter-usfm3/grammar.js
@@ -355,6 +355,8 @@ module.exports = grammar({
     //Table
     table: $ => prec.right(0, repeat1($.tr)),
     _tableText: $ => choice(
+      $.v,
+      $._verseMeta,
       $.verseText,
       $.footnote,
       $.crossref,
@@ -371,10 +373,10 @@ module.exports = grammar({
     thrTag: $=> /\\thr([12345](-[12345])?)?/,
     tcTag: $=> /\\tc([12345](-[12345])?)?/,
     tcrTag: $=> /\\tcr([12345](-[12345])?)?/,
-    th: $=> seq($.thTag, $._spaceOrLine, $._tableText),
-    thr: $=> seq($.thrTag, $._spaceOrLine, $._tableText),
-    tc: $=> seq($.tcTag, $._spaceOrLine, $._tableText),
-    tcr: $=> seq($.tcrTag, $._spaceOrLine, $._tableText),
+    th: $=> prec.right(0, seq($.thTag, $._spaceOrLine, repeat($._tableText))),
+    thr: $=> prec.right(0, seq($.thrTag, $._spaceOrLine, repeat($._tableText))),
+    tc: $=> prec.right(0, seq($.tcTag, $._spaceOrLine, repeat($._tableText))),
+    tcr: $=> prec.right(0, seq($.tcrTag, $._spaceOrLine, repeat($._tableText))),
 
     //Footnote
     caller: $ => /[^\s\\]+/,

--- a/tree-sitter-usfm3/package-lock.json
+++ b/tree-sitter-usfm3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-usfm3",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {
@@ -184,7 +184,7 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
@@ -207,7 +207,7 @@
       }
     },
     "node_modules/path-key": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
@@ -471,7 +471,7 @@
       "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw=="
     },
     "npm-run-path": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
@@ -489,7 +489,7 @@
       }
     },
     "path-key": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true

--- a/tree-sitter-usfm3/package.json
+++ b/tree-sitter-usfm3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-usfm3",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Grammar representation and parser for USFM language using tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/tree-sitter-usfm3/pyproject.toml
+++ b/tree-sitter-usfm3/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-usfm3"
 description = "Usfm3 grammar for tree-sitter"
-version = "3.1.1"
+version = "3.1.2"
 keywords = ["incremental", "parsing", "tree-sitter", "usfm3"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/web-usfm-parser/README.md
+++ b/web-usfm-parser/README.md
@@ -23,10 +23,10 @@ function App() {
 
   useEffect(() => {
     const initParser = async () => {
-      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
-      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
+      await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter.wasm");
+      await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter.wasm");
 
     };
     initParser();
@@ -60,13 +60,13 @@ It can be used directly in the HTML script tag too. Please ensure its dependenci
 
 ```html
 <script type="module">
-  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/dist/bundle.mjs';
+  import { USFMParser, Filter, Validator } from 'https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/dist/bundle.mjs';
   console.log('Hello world');
   (async () => {
-  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
-  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter-usfm.wasm",
-                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.1/tree-sitter.wasm");
+  await USFMParser.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter.wasm");
+  await Validator.init("https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter-usfm.wasm",
+                            "https://cdn.jsdelivr.net/npm/usfm-grammar-web@3.1.2/tree-sitter.wasm");
   const usfmParser = new USFMParser('\\id GEN\n\\c 1\n\\p\n\\v 1 In the begining..\\v 2 more text')
   const output = usfmParser.toUSJ()
   console.log({ output })

--- a/web-usfm-parser/package.json
+++ b/web-usfm-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-grammar-web",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Uses the tree-sitter-usfm3 parser to convert USFM files to other formats such as USJ, USX, and CS, and converts them back to USFM.",
   "type": "module",
   "module": "dist/bundle.mjs",

--- a/web-usfm-parser/src/usxGenerator.js
+++ b/web-usfm-parser/src/usxGenerator.js
@@ -25,6 +25,11 @@ class USXGenerator {
         } else {
             this.xmlRootNode = usxRootElement;
         }
+
+        this.parseState = {
+            prevVerseSid: null,
+            prevVerseParent: null
+        }
     }
 
     /**
@@ -137,56 +142,14 @@ class USXGenerator {
 
 	}
 
-	findPrevUncle(parentXmlNode) {
-        // Get the grandparent node
-        const grandParent = parentXmlNode.parentNode;
-        let uncleIndex = grandParent.childNodes.length - 2; // Start from the previous sibling
-
-        while (uncleIndex >= 0) {
-            const uncle = grandParent.childNodes[uncleIndex];
-
-            // Skip 'sidebar' and 'ms' elements
-            if (uncle.tagName === "sidebar" || uncle.tagName === "ms") {
-                uncleIndex--;
-            }
-            // Skip elements with 'ca' or 'cp' in the style attribute
-            else if (uncle.getAttribute('style') === 'ca' || uncle.getAttribute('style') === 'cp') {
-                uncleIndex--;
-            }
-            // Return the found uncle element
-            else {
-                return uncle;
-            }
-        }
-        return null;  // No suitable uncle found
-    }
-
     node2UsxVerse(node, parentXmlNode) {
-        // Find all previous 'verse' elements
-        const prevVerses = xpath.select("//verse", this.xmlRootNode);
 
-        // Check if there are previous verses and if the last one has a 'sid' attribute
-        if (prevVerses.length > 0 && prevVerses[prevVerses.length - 1].hasAttribute('sid')) {
-            let vEndXmlNode;
-            if (parentXmlNode.textContent.trim() !== "") {
-                // If there is verse text in the current parent
-                vEndXmlNode = parentXmlNode.ownerDocument.createElement('verse');
-                parentXmlNode.appendChild(vEndXmlNode);
-            } else {
-                // If no text, find the previous uncle and attach the end verse
-                const prevUncle = this.findPrevUncle(parentXmlNode);
-                if (prevUncle.tagName === "para") {
-                    vEndXmlNode = prevUncle.ownerDocument.createElement('verse');
-                    prevUncle.appendChild(vEndXmlNode);
-                } else if (prevUncle.tagName === "table") {
-                    const rows = prevUncle.getElementsByTagName('row');
-                    vEndXmlNode = prevUncle.ownerDocument.createElement('verse');
-                    rows[rows.length - 1].appendChild(vEndXmlNode);
-                } else {
-                    throw new Error(`prev_uncle is ${String(prevUncle)}`);
-                }
-            }
-            vEndXmlNode.setAttribute('eid', prevVerses[prevVerses.length - 1].getAttribute('sid'));
+        // Check if there are previous verses to close
+        if (this.parseState.prevVerseSid !== null) {
+            let prevPara = this.parseState.prevVerseParent;
+            let vEndXmlNode = prevPara.ownerDocument.createElement('verse');
+            vEndXmlNode.setAttribute("eid", this.parseState.prevVerseSid);
+            prevPara.appendChild(vEndXmlNode);
         }
 
         // Query to capture verse-related elements
@@ -227,6 +190,7 @@ class USXGenerator {
         vXmlNode.setAttribute('number', verseNum.trim());
         vXmlNode.setAttribute('style', 'v');
         vXmlNode.setAttribute('sid', ref.trim());
+        this.parseState.prevVerseSid = ref.trim();
     }
 
     node2UsxCaVa(node, parentXmlNode) {
@@ -537,6 +501,7 @@ class USXGenerator {
             node.children.forEach(child => {
                 this.node2Usx(child, parentXmlNode);
             });
+            this.parseState.prevVerseParent = parentXmlNode;
         } else if (["paragraph", "pi", "ph"].includes(node.type)) {
             this.node2UsxPara(node, parentXmlNode);
         } else if (NOTE_MARKERS.includes(node.type)) {


### PR DESCRIPTION
This PR
- fixes #326 
    - Issue: When table cells are empty or when a \v marker is in a cell it gives error. Upon ignoring the error verse data in table cell is lost.
    - Grammar update: Now both empty cells and cells with \v are accepted
    - USX generation challenge: As we need to find the correct previous element to add the verse end node for previous verse, a new verse in table cell required traversing the tree structure backwards. Existing logic failed for tables. Revised the logic by saving state of previous verse parent to avoid backtracking. This is in line with the new refactors brought in by @wkelly17 
- adds a new test case for the scenario
- bumps version to 3.1.2