### PR TITLE
New marker tcc

### DIFF
--- a/node-usfm-parser/src/usjGenerator.js
+++ b/node-usfm-parser/src/usjGenerator.js
@@ -304,7 +304,7 @@ class USJGenerator {
         type: "table:cell",
         marker: style,
         content: [],
-        align: style.includes("r") ? "end" : "start",
+        align: style.includes("tcc") ? "center" : style.includes("r") ? "end" : "start",
       };
       node.children.slice(1).forEach((child) => {
         this.nodeToUSJ(child, cellJsonObj);

--- a/node-usfm-parser/src/usxGenerator.js
+++ b/node-usfm-parser/src/usxGenerator.js
@@ -362,11 +362,12 @@ class USXGenerator {
             .trim();
           const cellXmlNode = parentXmlNode.ownerDocument.createElement("cell");
           cellXmlNode.setAttribute("style", style);
-          cellXmlNode.setAttribute("align", style.includes("r") ? "end" : "start");
+          cellXmlNode.setAttribute("align", style.includes("tcc") ? "center" : style.includes("r") ? "end" : "start");
           parentXmlNode.appendChild(cellXmlNode);
           node.children.slice(1).forEach((child) => {
             this.node2Usx(child, cellXmlNode);
           });
+          if style
         }
     }
 

--- a/node-usfm-parser/src/usxGenerator.js
+++ b/node-usfm-parser/src/usxGenerator.js
@@ -367,7 +367,6 @@ class USXGenerator {
           node.children.slice(1).forEach((child) => {
             this.node2Usx(child, cellXmlNode);
           });
-          if style
         }
     }
 

--- a/node-usfm-parser/src/utils/markers.js
+++ b/node-usfm-parser/src/utils/markers.js
@@ -122,5 +122,5 @@ exports.DEFAULT_ATTRIB_MAP = {
   "milestone": "who",
   "k":"key"
 };
-exports.TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"];
+exports.TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr", "tcc"];
 exports.MISC_MARKERS = ["fig", "cat", "esb", "b", "ph", "pi"];

--- a/node-usfm-parser/test/config.js
+++ b/node-usfm-parser/test/config.js
@@ -171,13 +171,13 @@ const checkValidUsfm = function (inputUsfmPath) {
 
 const findAllMarkers = function (usfmStr, keepId = false, keepNumber = true) {
   // Regex pattern to find all markers in the USFM string
-  let allMarkersInInput = [...usfmStr.matchAll(/\\\+?(([A-Za-z]+)\d*(-[se])?)/g)];
+  let allMarkersInInput = [...usfmStr.matchAll(/\\\+?(([A-Za-z]+)\d*(-\d+)?(-[se])?)/g)];
 
   // Processing based on `keepNumber` flag
   if (keepNumber) {
     allMarkersInInput = allMarkersInInput.map(match => match[1]);
   } else {
-    allMarkersInInput = allMarkersInInput.map(match => match[1] + match[2]);
+    allMarkersInInput = allMarkersInInput.map(match => match[1] + match[3]);
   }
 
   // Remove duplicates

--- a/py-usfm-parser/src/usfm_grammar/__main__.py
+++ b/py-usfm-parser/src/usfm_grammar/__main__.py
@@ -157,7 +157,10 @@ def main(): #pylint: disable=too-many-locals
             print(my_parser.usfm)
         case Format.BIBLENLP:
             infile = arg_parser.parse_args().infile
-            outfile_name = "".join(infile.split(".")[:-1]) + "_biblenlp.txt"
+            file_parts = infile.split(".")
+            file_parts[-1] = "txt"
+            file_parts[-2] += "_biblenlp"
+            outfile_name = ".".join(file_parts)
             outfile_name2 = outfile_name.replace("_biblenlp.txt", "_biblenlp_vref.txt")
             bible_nlp_dict = my_parser.to_biblenlp_format(ignore_errors=ignore_errors)
             with open(outfile_name, 'w', encoding='utf-8') as out1:

--- a/py-usfm-parser/src/usfm_grammar/usj_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usj_generator.py
@@ -230,6 +230,8 @@ class USJGenerator:
             cell_json_obj = {"type": "table:cell", "marker":style, "content":[]}
             if "r" in style:
                 cell_json_obj["align"] = "end"
+            elif "tcc" in style:
+                cell_json_obj["align"] = "center"
             else:
                 cell_json_obj["align"] = "start"
             for child in node.children[1:]:

--- a/py-usfm-parser/src/usfm_grammar/usx_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usx_generator.py
@@ -251,7 +251,7 @@ class USXGenerator:
             if "r" in style:
                 cell_xml_node.set("align", "end")
             elif "tcc" in style:
-                cell_xml_node.set("align", "center") 
+                cell_xml_node.set("align", "center")
             else:
                 cell_xml_node.set("align", "start")
             for child in node.children[1:]:

--- a/py-usfm-parser/src/usfm_grammar/usx_generator.py
+++ b/py-usfm-parser/src/usfm_grammar/usx_generator.py
@@ -31,7 +31,7 @@ class USXGenerator:
     DEFAULT_ATTRIB_MAP = {"w":"lemma", "rb":"gloss", "xt":"href", "fig":"alt",
                         "xt_standalone":"href", "xtNested":"href", "ref":"loc",
                         "milestone":"who", "k":"key"}
-    TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"]
+    TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr", "tcc"]
     MISC_MARKERS = ["fig", "cat", "esb", "b", "ph", "pi"]
 
     def __init__(self, tree_sitter_language_obj, usfm_bytes, usx_root_element=None):
@@ -250,6 +250,8 @@ class USXGenerator:
             cell_xml_node.set("style", style)
             if "r" in style:
                 cell_xml_node.set("align", "end")
+            elif "tcc" in style:
+                cell_xml_node.set("align", "center") 
             else:
                 cell_xml_node.set("align", "start")
             for child in node.children[1:]:

--- a/py-usfm-parser/tests/__init__.py
+++ b/py-usfm-parser/tests/__init__.py
@@ -59,11 +59,11 @@ def find_all_markers(usfm_path, keep_id=False, keep_number=True):
     '''To use regex pattern and finall markers in the USFM file'''
     with open(usfm_path, "r", encoding="utf-8") as in_usfm_file:
         usfm_str = in_usfm_file.read()
-        all_markers_in_input =re.findall(r"\\(([A-Za-z]+)\d*(-[se])?)", usfm_str)
+        all_markers_in_input =re.findall(r"\\(([A-Za-z]+)\d*(-\d+)?(-[se])?)", usfm_str)
     if keep_number:
         all_markers_in_input = [find[0] for find in all_markers_in_input]
     else:
-        all_markers_in_input = [find[1]+find[2] for find in all_markers_in_input]
+        all_markers_in_input = [find[1]+find[3] for find in all_markers_in_input]
     all_markers_in_input = list(set(all_markers_in_input))
     if not keep_id:
         all_markers_in_input.remove("id")

--- a/tests/bugfixes/tcc/metadata.xml
+++ b/tests/bugfixes/tcc/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-metadata>
+        <description>A new marker \tcc is introduced. https://docs.usfm.bible/usfm/3.1/char/tables/tcc.html</description>
+        <validated>pass</validated>
+        <tags></tags>
+</test-metadata>

--- a/tests/bugfixes/tcc/origin.json
+++ b/tests/bugfixes/tcc/origin.json
@@ -1,0 +1,178 @@
+{
+    "type": "USJ",
+    "version": "3.1",
+    "content": [
+        {
+            "type": "book",
+            "marker": "id",
+            "content": [],
+            "code": "NUM"
+        },
+        {
+            "type": "chapter",
+            "marker": "c",
+            "number": "2",
+            "sid": "NUM 2"
+        },
+        {
+            "type": "para",
+            "marker": "p",
+            "content": [
+                {
+                    "type": "verse",
+                    "marker": "v",
+                    "number": "3-9",
+                    "sid": "NUM 2:3-9"
+                },
+                "On the east side, those under the banner of the division of Judah\nshall camp in their groups, under their leaders, as follows:\n"
+            ]
+        },
+        {
+            "type": "table",
+            "content": [
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "th1",
+                            "content": [
+                                "Tribe "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "th2",
+                            "content": [
+                                "Leader "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "thr3",
+                            "content": [
+                                "Number\n"
+                            ],
+                            "align": "end"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [
+                                "Judah "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tc2",
+                            "content": [
+                                "Nahshon son of Amminadab "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcc3",
+                            "content": [
+                                "74,600\n"
+                            ],
+                            "align": "center"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [
+                                "Issachar "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tc2",
+                            "content": [
+                                "Nethanel son of Zuar "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcc3",
+                            "content": [
+                                "54,400\n"
+                            ],
+                            "align": "center"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tc1",
+                            "content": [
+                                "Zebulun "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tc2",
+                            "content": [
+                                "Eliab son of Helon "
+                            ],
+                            "align": "start"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcc3",
+                            "content": [
+                                "57,400\n"
+                            ],
+                            "align": "center"
+                        }
+                    ]
+                },
+                {
+                    "type": "table:row",
+                    "marker": "tr",
+                    "content": [
+                        {
+                            "type": "table:cell",
+                            "marker": "tcr1-2",
+                            "content": [
+                                "Total: "
+                            ],
+                            "align": "end"
+                        },
+                        {
+                            "type": "table:cell",
+                            "marker": "tcc3",
+                            "content": [
+                                "186,400"
+                            ],
+                            "align": "center"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/bugfixes/tcc/origin.usfm
+++ b/tests/bugfixes/tcc/origin.usfm
@@ -1,0 +1,10 @@
+\id NUM
+\c 2
+\p
+\v 3-9 On the east side, those under the banner of the division of Judah
+shall camp in their groups, under their leaders, as follows:
+\tr \th1 Tribe \th2 Leader \thr3 Number
+\tr \tc1 Judah \tc2 Nahshon son of Amminadab \tcc3 74,600
+\tr \tc1 Issachar \tc2 Nethanel son of Zuar \tcc3 54,400
+\tr \tc1 Zebulun \tc2 Eliab son of Helon \tcc3 57,400
+\tr \tcr1-2 Total: \tcc3 186,400

--- a/tests/bugfixes/tcc/origin.xml
+++ b/tests/bugfixes/tcc/origin.xml
@@ -1,0 +1,40 @@
+<usx version="3.1">
+  <book code="NUM" style="id"/>
+  <chapter number="2" style="c" sid="NUM 2"/>
+  <para style="p"><verse number="3-9" style="v" sid="NUM 2:3-9"/>On the east side, those under the banner of the division of Judah
+shall camp in their groups, under their leaders, as follows:
+</para>
+  <table>
+    <row style="tr">
+      <cell style="th1" align="start">Tribe </cell>
+      <cell style="th2" align="start">Leader </cell>
+      <cell style="thr3" align="end">Number
+</cell>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start">Judah </cell>
+      <cell style="tc2" align="start">Nahshon son of Amminadab </cell>
+      <cell style="tcc3" align="center">74,600
+</cell>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start">Issachar </cell>
+      <cell style="tc2" align="start">Nethanel son of Zuar </cell>
+      <cell style="tcc3" align="center">54,400
+</cell>
+    </row>
+    <row style="tr">
+      <cell style="tc1" align="start">Zebulun </cell>
+      <cell style="tc2" align="start">Eliab son of Helon </cell>
+      <cell style="tcc3" align="center">57,400
+</cell>
+    </row>
+    <row style="tr">
+      <cell style="tcr1-2" align="end">Total: </cell>
+      <cell style="tcc3" align="center">186,400</cell>
+      <verse eid="NUM 2:3-9"/>
+    </row>
+  </table>
+  <chapter eid="NUM 2"/>
+</usx>
+

--- a/tree-sitter-usfm3/grammar.js
+++ b/tree-sitter-usfm3/grammar.js
@@ -368,16 +368,19 @@ module.exports = grammar({
       $.th,
       $.thr,
       $.tc,
-      $.tcr))
+      $.tcr,
+      $.tcc))
     )),
     thTag: $=> /\\th(\d+(-\d+)?)?/,
     thrTag: $=> /\\thr(\d+(-\d+)?)?/,
     tcTag: $=> /\\tc(\d+(-\d+)?)?/,
     tcrTag: $=> /\\tcr(\d+(-\d+)?)?/,
+    tccTag: $=> /\\tcc(\d+(-\d+)?)?/,
     th: $=> prec.right(0, seq($.thTag, $._spaceOrLine, repeat($._tableText))),
     thr: $=> prec.right(0, seq($.thrTag, $._spaceOrLine, repeat($._tableText))),
     tc: $=> prec.right(0, seq($.tcTag, $._spaceOrLine, repeat($._tableText))),
     tcr: $=> prec.right(0, seq($.tcrTag, $._spaceOrLine, repeat($._tableText))),
+    tcc: $=> prec.right(0, seq($.tccTag, $._spaceOrLine, repeat($._tableText))),
 
     //Footnote
     caller: $ => /[^\s\\]+/,

--- a/web-usfm-parser/src/usjGenerator.js
+++ b/web-usfm-parser/src/usjGenerator.js
@@ -304,7 +304,7 @@ class USJGenerator {
         type: "table:cell",
         marker: style,
         content: [],
-        align: style.includes("r") ? "end" : "start",
+        align: style.includes("tcc") ? "center" : style.includes("r") ? "end" : "start",
       };
       node.children.slice(1).forEach((child) => {
         this.nodeToUSJ(child, cellJsonObj);

--- a/web-usfm-parser/src/usxGenerator.js
+++ b/web-usfm-parser/src/usxGenerator.js
@@ -365,7 +365,7 @@ class USXGenerator {
             .trim();
           const cellXmlNode = parentXmlNode.ownerDocument.createElement("cell");
           cellXmlNode.setAttribute("style", style);
-          cellXmlNode.setAttribute("align", style.includes("r") ? "end" : "start");
+          cellXmlNode.setAttribute("align", style.includes("tcc") ? "center" : style.includes("r") ? "end" : "start");
           parentXmlNode.appendChild(cellXmlNode);
           node.children.slice(1).forEach((child) => {
             this.node2Usx(child, cellXmlNode);

--- a/web-usfm-parser/src/utils/markers.js
+++ b/web-usfm-parser/src/utils/markers.js
@@ -120,5 +120,5 @@ export const DEFAULT_ATTRIB_MAP = {
   "milestone": "who",
   "k":"key"
 };
-export const TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr"];
+export const TABLE_CELL_MARKERS = ["tc", "th", "tcr", "thr", "tcc"];
 export const MISC_MARKERS = ["fig", "cat", "esb", "b", "ph", "pi"];

--- a/web-usfm-parser/test/config.js
+++ b/web-usfm-parser/test/config.js
@@ -177,13 +177,13 @@ const checkValidUsfm = function (inputUsfmPath) {
 
 const findAllMarkers = function (usfmStr, keepId = false, keepNumber = true) {
   // Regex pattern to find all markers in the USFM string
-  let allMarkersInInput = [...usfmStr.matchAll(/\\\+?(([A-Za-z]+)\d*(-[se])?)/g)];
+  let allMarkersInInput = [...usfmStr.matchAll(/\\\+?(([A-Za-z]+)\d*(-\d+)?(-[se])?)/g)];
 
   // Processing based on `keepNumber` flag
   if (keepNumber) {
     allMarkersInInput = allMarkersInInput.map(match => match[1]);
   } else {
-    allMarkersInInput = allMarkersInInput.map(match => match[1] + match[2]);
+    allMarkersInInput = allMarkersInInput.map(match => match[1] + match[3]);
   }
 
   // Remove duplicates


### PR DESCRIPTION
- Fixes #333, by including `\tcc` in grammar rules and  conversion methods
- Add a test case.