### PR TITLE
Hotfix/pypi publish june2025

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,6 +35,8 @@ jobs:
           cd tree-sitter-usfm3
           python -m pip install build setuptools
           python -m build
+          ls tree-sitter-usfm3/dist/
+          ls tree-sitter-usfm3/dist/ | grep .whl
           rm tree-sitter-usfm3/dist/*.whl
 
       - name: Publish tree-sitter-usfm3 📦 to PyPI

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -7,7 +7,7 @@ on:
     types: [published]
 
 jobs:
-  build-n-publish-tree-sitter-usfm3:
+  publish-tree-sitter-usfm3:
     runs-on: ubuntu-latest
     
     steps:
@@ -42,11 +42,10 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           # repository_url: https://test.pypi.org/legacy/
-          packages-dir: tree-sitter-usfm3/dist/
-          
-  build-n-publish-py-usfm-parser:
+          packages_dir: tree-sitter-usfm3/dist/
+
+  publish-py-usfm-parser:
     runs-on: ubuntu-latest
-    needs: [build-n-publish-tree-sitter-usfm3]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -57,11 +56,16 @@ jobs:
           cd py-usfm-parser
           python -m pip install build setuptools
           python -m build
-
       - name: Publish usfm-grammar 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
           # repository_url: https://test.pypi.org/legacy/
-          packages-dir: py-usfm-parser/dist/
+          packages_dir: py-usfm-parser/dist/
+
+
+
+
+
+          

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -7,7 +7,7 @@ on:
     types: [published]
 
 jobs:
-  build-tree-sitter-usfm3:
+  build-n-publish-tree-sitter-usfm3:
     runs-on: ubuntu-latest
     
     steps:
@@ -35,13 +35,18 @@ jobs:
           cd tree-sitter-usfm3
           python -m pip install build setuptools
           python -m build
-      - uses: actions/upload-artifact@v4
-        with:
-          path: tree-sitter-usfm3/dist/*.tar.gz
-          overwrite: true
 
-  build-py-usfm-parser:
+      - name: Publish tree-sitter-usfm3 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}
+          # repository_url: https://test.pypi.org/legacy/
+          packages-dir: tree-sitter-usfm3/dist/
+          
+  build-n-publish-py-usfm-parser:
     runs-on: ubuntu-latest
+    needs: [build-n-publish-tree-sitter-usfm3]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -52,39 +57,6 @@ jobs:
           cd py-usfm-parser
           python -m pip install build setuptools
           python -m build
-      - uses: actions/upload-artifact@v4
-        with:
-          path: py-usfm-parser/dist/*.tar.gz
-          overwrite: true
-
-
-  publish_to_pypi:
-    needs: [build-tree-sitter-usfm3, build-py-usfm-parser]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - uses: actions/download-artifact@v4
-        with:
-          name: artifact
-          path: tree-sitter-usfm3/dist/
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: artifact
-          path: py-usfm-parser/dist/
-
-      - name: Publish tree-sitter-usfm3 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
-          # repository_url: https://test.pypi.org/legacy/
-          packages_dir: tree-sitter-usfm3/dist/
 
       - name: Publish usfm-grammar 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -92,5 +64,4 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           # repository_url: https://test.pypi.org/legacy/
-          packages_dir: py-usfm-parser/dist/
-          
+          packages-dir: py-usfm-parser/dist/

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -34,10 +34,7 @@ jobs:
         run: |
           cd tree-sitter-usfm3
           python -m pip install build setuptools
-          python -m build
-          ls tree-sitter-usfm3/dist/
-          ls tree-sitter-usfm3/dist/ | grep .whl
-          rm tree-sitter-usfm3/dist/*.whl
+          python -m build --sdist
 
       - name: Publish tree-sitter-usfm3 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -45,7 +42,7 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           # repository_url: https://test.pypi.org/legacy/
-          packages_dir: tree-sitter-usfm3/dist/
+          packages-dir: tree-sitter-usfm3/dist/
 
   publish-py-usfm-parser:
     runs-on: ubuntu-latest
@@ -58,8 +55,7 @@ jobs:
         run: |
           cd py-usfm-parser
           python -m pip install build setuptools
-          python -m build
-          rm py-usfm-parser/dist/*.whl
+          python -m build --sdist
 
       - name: Publish usfm-grammar 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -67,7 +63,7 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           # repository_url: https://test.pypi.org/legacy/
-          packages_dir: py-usfm-parser/dist/
+          packages-dir: py-usfm-parser/dist/
 
 
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,6 +35,7 @@ jobs:
           cd tree-sitter-usfm3
           python -m pip install build setuptools
           python -m build
+          rm tree-sitter-usfm3/dist/*.whl
 
       - name: Publish tree-sitter-usfm3 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -56,6 +57,8 @@ jobs:
           cd py-usfm-parser
           python -m pip install build setuptools
           python -m build
+          rm py-usfm-parser/dist/*.whl
+
       - name: Publish usfm-grammar 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -1,11 +1,13 @@
-name: Publish to TestPyPI 
+name: PyPI Publish
 
 on:
-  # push: # need to use this temporarly to be able to publish
-  workflow_dispatch: # works only on default branch
+  # push:
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
-  build-tree-sitter-usfm3:
+  build-n-publish-tree-sitter-usfm3:
     runs-on: ubuntu-latest
     
     steps:
@@ -24,7 +26,7 @@ jobs:
           ./node_modules/.bin/tree-sitter generate
           ./node_modules/.bin/tree-sitter test
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -33,11 +35,16 @@ jobs:
           cd tree-sitter-usfm3
           python -m pip install build setuptools
           python -m build
-      - uses: actions/upload-artifact@v3
-        with:
-          path: tree-sitter-usfm3/dist/*.tar.gz
 
-  build-py-usfm-parser:
+      - name: Publish tree-sitter-usfm3 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}
+          repository_url: https://test.pypi.org/legacy/
+          packages-dir: tree-sitter-usfm3/dist/
+          
+  build-n-publish-py-usfm-parser:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,44 +56,11 @@ jobs:
           cd py-usfm-parser
           python -m pip install build setuptools
           python -m build
-      - uses: actions/upload-artifact@v3
-        with:
-          path: py-usfm-parser/dist/*.tar.gz
 
-
-  publish_to_pypi:
-    needs: [build-tree-sitter-usfm3, build-py-usfm-parser]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: tree-sitter-usfm3/dist/
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: py-usfm-parser/dist/
-
-      - name: Publish tree-sitter-usfm3 📦 to Test PyPI
+      - name: Publish usfm-grammar 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PUBLISH_ON_TEST_PYPI }}
+          password: ${{ secrets.pypi_token }}
           repository_url: https://test.pypi.org/legacy/
-          packages_dir: tree-sitter-usfm3/dist/
-
-      - name: Publish usfm-grammar 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PUBLISH_ON_TEST_PYPI }}
-          repository_url: https://test.pypi.org/legacy/
-          packages_dir: py-usfm-parser/dist/
-          
+          packages-dir: py-usfm-parser/dist/

--- a/.github/workflows/testpypi_publish.yml
+++ b/.github/workflows/testpypi_publish.yml
@@ -40,7 +40,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.pypi_token }}
+          password: ${{ secrets.PUBLISH_ON_TEST_PYPI }}
           repository_url: https://test.pypi.org/legacy/
           packages-dir: tree-sitter-usfm3/dist/
           
@@ -61,6 +61,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.pypi_token }}
+          password: ${{ secrets.PUBLISH_ON_TEST_PYPI }}
           repository_url: https://test.pypi.org/legacy/
           packages-dir: py-usfm-parser/dist/


### PR DESCRIPTION
- Avoids using artifact upload and download between different jobs which was causing issues since previous release.
- Published python usfm-grammar 3.1.2 to pypi which failed in the release pipeline.